### PR TITLE
Upgrades to ProcessingChain and WaveformBrowser

### DIFF
--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -212,7 +212,9 @@ class ProcChainVar:
             )
 
         # if variable has no convertable units, we're all set
-        if self.unit is None or not (isinstance(self.unit, (Unit, Quantity)) or self.unit in ureg):
+        if self.unit is None or not (
+            isinstance(self.unit, (Unit, Quantity)) or self.unit in ureg
+        ):
             return self._buffer
         elif not isinstance(self._buffer, list):
             self._buffer = [(self._buffer, self.unit)]
@@ -1291,7 +1293,9 @@ class UnitConversionManager(ProcessorManager):
         else:
             raise DSPFatal("Cannot convert to integer")
 
-    def __init__(self, var: ProcChainVar, unit: str | Unit | Quantity | CoordinateGrid) -> None:
+    def __init__(
+        self, var: ProcChainVar, unit: str | Unit | Quantity | CoordinateGrid
+    ) -> None:
         # reference back to our processing chain
         self.proc_chain = var.proc_chain
         # callable function used to process data
@@ -1307,7 +1311,7 @@ class UnitConversionManager(ProcessorManager):
         if isinstance(unit, CoordinateGrid):
             to_offset = unit.get_offset()
             unit = unit.period
-        
+
         from_buffer, from_unit = var._buffer[0]
         if isinstance(from_unit, CoordinateGrid):
             ratio = from_unit.get_period(unit)
@@ -1317,7 +1321,7 @@ class UnitConversionManager(ProcessorManager):
                 unit = ureg.Quantity(unit)
             ratio = float(from_unit / unit)
             from_offset = 0
-        
+
         self.out_buffer = np.zeros_like(from_buffer, dtype=var.dtype)
         self.args = [
             from_buffer,
@@ -1405,7 +1409,7 @@ class LGDOArrayIOManager(IOManager):
                 var_u = var.unit.u
             else:
                 var_u = var.unit
-            
+
             if unit is None:
                 unit = var_u
             elif ureg.is_compatible_with(var_u, unit):

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -215,7 +215,7 @@ class ProcChainVar:
                 shape=(self.proc_chain._block_width,) + self.shape, dtype=self.dtype
             )
 
-        # if variable has no convertable units, we're all set
+        # if variable has no convertible units, we're all set
         if isinstance(self._buffer, np.ndarray) and (self.unit is None or not (
             isinstance(self.unit, (Unit, Quantity)) or self.unit in ureg
         ) ):

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -186,7 +186,7 @@ class ProcChainVar:
             value = CoordinateGrid(period, offset)
 
         elif name == "unit" and value is not None:
-            value = str(value)
+            value = value
 
         elif name == "is_coord":
             value = bool(value)
@@ -211,16 +211,18 @@ class ProcChainVar:
                 shape=(self.proc_chain._block_width,) + self.shape, dtype=self.dtype
             )
 
-        # if variable isn't a coordinate, we're all set
-        if self.is_coord is False or self.is_coord is auto:
+        # if variable has no convertable units, we're all set
+        if self.unit is None or not (isinstance(self.unit, (Unit, Quantity)) or self.unit in ureg):
             return self._buffer
+        elif not isinstance(self._buffer, list):
+            self._buffer = [(self._buffer, self.unit)]
 
         # if no unit is given, use the native unit
         if unit is None:
-            if isinstance(self.unit, str):
-                unit = CoordinateGrid(self.unit, 0.0)
-        elif not isinstance(unit, CoordinateGrid):
-            unit = CoordinateGrid(unit, 0.0)
+            unit = self.unit
+
+        if self.is_coord and not isinstance(unit, CoordinateGrid):
+            unit = CoordinateGrid(unit, 0)
 
         # if this is our first time accessing, no conversion is needed
         if len(self._buffer) == 0:
@@ -236,8 +238,8 @@ class ProcChainVar:
             return buff
 
         # check if coordinate conversion has been done already
-        for buff, grid in self._buffer:
-            if grid == unit:
+        for buff, buf_u in self._buffer:
+            if buf_u == unit:
                 return buff
 
         # If we get this far, add conversion processor to ProcChain and add new buffer to _buffer
@@ -1289,7 +1291,7 @@ class UnitConversionManager(ProcessorManager):
         else:
             raise DSPFatal("Cannot convert to integer")
 
-    def __init__(self, var: ProcChainVar, unit: str | Unit) -> None:
+    def __init__(self, var: ProcChainVar, unit: str | Unit | Quantity | CoordinateGrid) -> None:
         # reference back to our processing chain
         self.proc_chain = var.proc_chain
         # callable function used to process data
@@ -1301,14 +1303,27 @@ class UnitConversionManager(ProcessorManager):
         self.params = [var, unit]
         self.kw_params = {}
 
-        from_buffer, from_grid = var._buffer[0]
-        period_ratio = from_grid.get_period(unit.period)
+        to_offset = 0
+        if isinstance(unit, CoordinateGrid):
+            to_offset = unit.get_offset()
+            unit = unit.period
+        
+        from_buffer, from_unit = var._buffer[0]
+        if isinstance(from_unit, CoordinateGrid):
+            ratio = from_unit.get_period(unit)
+            from_offset = from_unit.get_offset()
+        elif isinstance(from_unit, (str, Unit, Quantity)):
+            if isinstance(unit, str):
+                unit = ureg.Quantity(unit)
+            ratio = float(from_unit / unit)
+            from_offset = 0
+        
         self.out_buffer = np.zeros_like(from_buffer, dtype=var.dtype)
         self.args = [
             from_buffer,
-            from_grid.get_offset(),
-            unit.get_offset(),
-            period_ratio,
+            from_offset,
+            to_offset,
+            ratio,
             self.out_buffer,
         ]
         self.kwargs = {}
@@ -1383,19 +1398,28 @@ class LGDOArrayIOManager(IOManager):
         unit = io_array.attrs.get("units", None)
         var.update_auto(dtype=io_array.dtype, shape=io_array.nda.shape[1:], unit=unit)
 
-        if isinstance(var.unit, CoordinateGrid):
+        if isinstance(var.unit, (CoordinateGrid, Quantity, Unit)):
+            if isinstance(var.unit, CoordinateGrid):
+                var_u = var.unit.period.u
+            elif isinstance(var.unit, Quantity):
+                var_u = var.unit.u
+            else:
+                var_u = var.unit
+            
             if unit is None:
-                unit = var.unit.period.u
-            elif ureg.is_compatible_with(var.unit.period, unit):
+                unit = var_u
+            elif ureg.is_compatible_with(var_u, unit):
                 unit = ureg.Quantity(unit).u
             else:
                 raise ProcessingChainError(
                     f"LGDO array and variable {var} have incompatible units "
-                    f"({var.unit.period.u} and {unit})"
+                    f"({var_u} and {unit})"
                 )
+        elif isinstance(var.unit, str) and unit is None:
+            unit = var.unit
 
-        if unit is None and var.unit is not None:
-            io_array.attrs["units"] = str(var.unit)
+        if "units" not in io_array.attrs and unit is not None:
+            io_array.attrs["units"] = str(unit)
 
         self.io_array = io_array
         self.raw_buf = io_array.nda

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -60,7 +60,7 @@ class CoordinateGrid:
         if isinstance(self.period, CoordinateGrid):
             self.offset = self.period.offset
             self.period = self.period.period
-        
+
         if isinstance(self.period, str):
             self.period = Quantity(1.0, self.period)
         elif isinstance(self.period, Unit):
@@ -216,9 +216,10 @@ class ProcChainVar:
             )
 
         # if variable has no convertible units, we're all set
-        if isinstance(self._buffer, np.ndarray) and (self.unit is None or not (
-            isinstance(self.unit, (Unit, Quantity)) or self.unit in ureg
-        ) ):
+        if isinstance(self._buffer, np.ndarray) and (
+            self.unit is None
+            or not (isinstance(self.unit, (Unit, Quantity)) or self.unit in ureg)
+        ):
             return self._buffer
 
         # buffer can be converted, so make it a list of buffers

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -171,9 +171,7 @@ class WaveformBrowser:
 
         self.aux_vals = aux_values
         # Apply entry selection to aux_vals if needed
-        if self.aux_vals is not None and len(self.aux_vals) > len(
-            self.lh5_it.get_global_entrylist()
-        ):
+        if self.aux_vals is not None and self.lh5_it.get_global_entrylist() is not None and len(self.aux_vals) > len(self.lh5_it.get_global_entrylist()):
             self.aux_vals = self.aux_vals.iloc[
                 self.lh5_it.get_global_entrylist()
             ].reset_index()

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -189,7 +189,6 @@ class WaveformBrowser:
             self.lines = {line: [] for line in lines}
 
         # styles
-        default_style = itertools.cycle(cycler(plt.rcParams["axes.prop_cycle"]))
         if isinstance(styles, (list, tuple)):
             self.styles = [None for _ in self.lines]
             for i, sty in enumerate(styles):
@@ -197,21 +196,21 @@ class WaveformBrowser:
                     try:
                         self.styles[i] = plt.style.library[sty]["axes.prop_cycle"]
                     except KeyError:
-                        self.styles[i] = itertools.repeat(None)
+                        self.styles[i] = None
                 elif sty is None:
-                    self.styles[i] = default_style
+                    self.styles[i] = None
                 else:
-                    self.styles[i] = cycler(**sty)
+                    self.styles[i] = itertools.cycle(cycler(**sty))
         else:
             if isinstance(styles, str):
                 try:
                     self.styles = plt.style.library[styles]["axes.prop_cycle"]
                 except KeyError:
-                    self.styles = itertools.repeat(None)
+                    self.styles = None
             elif styles is None:
-                self.styles = default_style
+                self.styles = None
             else:
-                self.styles = cycler(**styles)
+                self.styles = itertools.cycle(cycler(**styles))
 
         self.legend_format = []  # list of formatter strings
         self.legend_vals = {}  # Set up dict from names to lists of values
@@ -500,9 +499,14 @@ class WaveformBrowser:
         default_style = itertools.cycle(cycler(plt.rcParams["axes.prop_cycle"]))
         for i, lines in enumerate(self.lines.values()):
             if isinstance(self.styles, list):
-                styles = itertools.cycle(iter(self.styles[i]))
+                styles = self.styles[i]
+            else:
+                styles = self.styles
+            
             if styles is None:
                 styles = default_style
+            else:
+                styles = iter(styles)
 
             # for line, sty in zip(lines, styles):
             for line in lines:

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -185,7 +185,7 @@ class WaveformBrowser:
             self.lines = {line: [] for line in lines}
 
         # styles
-        default_style = cycler(plt.rcParams["axes.prop_cycle"])
+        default_style = itertools.cycle(cycler(plt.rcParams["axes.prop_cycle"]))
         if isinstance(styles, (list, tuple)):
             self.styles = [None for _ in self.lines]
             for i, sty in enumerate(styles):
@@ -493,14 +493,16 @@ class WaveformBrowser:
             styles = self.styles
 
         # draw lines
-        default_style = cycler(plt.rcParams["axes.prop_cycle"])
+        default_style = itertools.cycle(cycler(plt.rcParams["axes.prop_cycle"]))
         for i, lines in enumerate(self.lines.values()):
             if isinstance(self.styles, list):
-                styles = self.styles[i]
+                styles = itertools.cycle(iter(self.styles[i]))
             if styles is None:
                 styles = default_style
 
-            for line, sty in zip(lines, itertools.cycle(styles)):
+            #for line, sty in zip(lines, styles):
+            for line in lines:
+                sty = next(styles)
                 if sty is not None:
                     line.update(sty)
                 if line.get_figure() is not None:

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -502,7 +502,7 @@ class WaveformBrowser:
                 styles = self.styles[i]
             else:
                 styles = self.styles
-            
+
             if styles is None:
                 styles = default_style
             else:

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -171,7 +171,11 @@ class WaveformBrowser:
 
         self.aux_vals = aux_values
         # Apply entry selection to aux_vals if needed
-        if self.aux_vals is not None and self.lh5_it.get_global_entrylist() is not None and len(self.aux_vals) > len(self.lh5_it.get_global_entrylist()):
+        if (
+            self.aux_vals is not None
+            and self.lh5_it.get_global_entrylist() is not None
+            and len(self.aux_vals) > len(self.lh5_it.get_global_entrylist())
+        ):
             self.aux_vals = self.aux_vals.iloc[
                 self.lh5_it.get_global_entrylist()
             ].reset_index()
@@ -500,7 +504,7 @@ class WaveformBrowser:
             if styles is None:
                 styles = default_style
 
-            #for line, sty in zip(lines, styles):
+            # for line, sty in zip(lines, styles):
             for line in lines:
                 sty = next(styles)
                 if sty is not None:


### PR DESCRIPTION
- ProcessingChain can now accept pint Quantities (e.g. `10*ns`) as units in dsp config files. When writing to output files, the unit attribute will use only the unit component, and the value will be converted into that unit. For example, if you had a value of 100 and unit of 16*ns, it would write as 1600 with an attribute of "nanoseconds". The unit can also be fed units from other variables; for example, you can do `unit=waveform.period`.
- Feeding aux values to the waveform browser was broken when no entry list was given
- When drawing multiple different waveforms with no style given, loop through the default style. Previously this was done if multiple of the same waveform variable was drawn, but not if different ones were.