### PR TITLE
Added general transfer function convolver

### DIFF
--- a/src/dspeed/processors/__init__.py
+++ b/src/dspeed/processors/__init__.py
@@ -89,6 +89,7 @@ from .saturation import saturation
 from .soft_pileup_corr import soft_pileup_corr, soft_pileup_corr_bl
 from .time_over_threshold import time_over_threshold
 from .time_point_thresh import interpolated_time_point_thresh, time_point_thresh
+from .transfer_function_convolver import transfer_function_convolver
 from .trap_filters import asym_trap_filter, trap_filter, trap_norm, trap_pickoff
 from .upsampler import interpolating_upsampler, upsampler
 from .wiener_filter import wiener_filter
@@ -144,4 +145,5 @@ __all__ = [
     "time_over_threshold",
     "dplms",
     "moving_slope",
+    "transfer_function_convolver",
 ]

--- a/src/dspeed/processors/transfer_function_convolver.py
+++ b/src/dspeed/processors/transfer_function_convolver.py
@@ -19,7 +19,9 @@ def transfer_function_convolver(w_in, a_in, b_in, w_out):
     r"""
     Compute the difference equation of the form
     $a_0*w_out[i] = a_1*w_out[i-1] + \ldots b_0*w_in[i] \ldots$
-    which is equivalent of convolving a signal with a transfer function
+    which is equivalent of convolving a signal with a transfer function.
+    a_in always needs at least one element
+    The numba signature specifies these arrays as contiguous, so that way the dot product is as fast as possible
 
     Parameters
     ----------
@@ -40,14 +42,9 @@ def transfer_function_convolver(w_in, a_in, b_in, w_out):
         "wf_pz": {
             "function": "transfer_function_convolver",
             "module": "dspeed.processors",
-            "args": ["wf_bl", np.array([1, 1]), np.array([1, -0.1]), "wf_pz"],
+            "args": ["waveform", "np.array([-1,1])", "np.array([1,2])", "wf_pz"],
             "unit": "ADC"
         }
-
-    Notes
-    -----
-    a_in always needs at least one element
-    The numba signature specifies these arrays as contiguous, so that way the dot product is as fast as possible
     """
     w_out[:] = np.nan
 

--- a/src/dspeed/processors/transfer_function_convolver.py
+++ b/src/dspeed/processors/transfer_function_convolver.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import numpy as np
+from numba import guvectorize
+
+from ..errors import DSPFatal
+from ..utils import numba_defaults_kwargs as nb_kwargs
+
+
+@guvectorize(
+    [
+        "void(float32[::1], float32[:], float32[:], float32[::1])",
+        "void(float64[::1], float64[:], float64[:], float64[::1])",
+    ],
+    "(n),(m),(l)->(n)",
+    **nb_kwargs,
+)
+def transfer_function_convolver(w_in, a_in, b_in, w_out):
+    r"""
+    Compute the difference equation of the form
+    $a_0*w_out[i] = a_1*w_out[i-1] + \ldots b_0*w_in[i] \ldots$
+    which is equivalent of convolving a signal with a transfer function
+
+    Parameters
+    ----------
+    w_in
+        An array of the values that this lti filter will be performed on
+    a_in
+        An array [a_0, ..., a_n] of filter coefficients to apply recursively to the output
+    b_in
+        An array [b_0, ..., b_m] of filter coefficients to apply to the input
+    w_out
+        The output array to store all the filtered values
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "wf_pz": {
+            "function": "transfer_function_convolver",
+            "module": "dspeed.processors",
+            "args": ["wf_bl", np.array([1, 1]), np.array([1, -0.1]), "wf_pz"],
+            "unit": "ADC"
+        }
+
+    Notes
+    -----
+    a_in always needs at least one element
+    The numba signature specifies these arrays as contiguous, so that way the dot product is as fast as possible
+    """
+    w_out[:] = np.nan
+
+    # perform some checks
+    if np.isnan(w_in).any() or np.isnan(a_in).any() or np.isnan(b_in).any():
+        return
+    if len(w_in) != len(w_out):
+        return
+    if len(a_in) < 1:
+        raise DSPFatal("The parameter a_in must be an array of length at least 1")
+
+    b = b_in / a_in[0]
+    a = a_in / a_in[0]
+
+    # copy and flip the arrays, needed so that way they are contiguous
+    a_flip = np.copy(a[::-1])
+    b_flip = np.copy(b[::-1])
+
+    # Figure out if it's a FIR
+    if a_flip.size == 1:
+        # Perform the convolution
+        for n in range(0, w_in.size):
+            w_out[n] = np.dot(b_flip[-(n + 1) :], w_in[n + 1 - len(b_flip) : n + 1])
+
+    # Otherwise we have an IIR
+    else:
+        a_flip = a_flip[:-1]
+        # Initialize the output with the first input signals
+        for i in range(a_flip.size):
+            w_out[i] = w_in[i]
+
+        # Perform the convolution
+        for n in range(a_flip.size, w_in.size):
+            w_out[n] = np.dot(a_flip, w_out[n - len(a_flip) : n])
+            w_out[n] += np.dot(b_flip[-(n + 1) :], w_in[n + 1 - len(b_flip) : n + 1])

--- a/tests/processors/test_transfer_function_convolver.py
+++ b/tests/processors/test_transfer_function_convolver.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+from dspeed.errors import DSPFatal
+from dspeed.processors import pole_zero, transfer_function_convolver
+
+
+def test_transfer_function_convolver(compare_numba_vs_python):
+    """
+    Testing function for the transfer_function_convolver processor.
+    Test that this function reproduces a single pole zero filter
+
+    """
+
+    # Create a single exponential pulse to pole-zero correct
+    tau = 10
+    ts = np.arange(0, 100)
+    amplitude = 10
+    pulse_in = np.insert(amplitude * np.exp(-ts / tau), 0, np.zeros(20))
+
+    a_in = np.array([1, 1], dtype=np.float64)
+    b_in = np.array([1, -np.exp(-1 / tau)], dtype=np.float64)
+    pulse_out = np.zeros(pulse_in.size, dtype=np.float64)
+
+    # ensure the DSPFatal is raised if the parameter a is a scalar
+    with pytest.raises(DSPFatal):
+        transfer_function_convolver(pulse_in, np.array([]), b_in, pulse_out)
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in = np.ones(pulse_in.size)
+    w_in[4] = np.nan
+
+    assert np.all(
+        np.isnan(compare_numba_vs_python(transfer_function_convolver, w_in, a_in, b_in))
+    )
+
+    # ensure that if there is a nan in a_in, all nans are outputted
+    a_wrong_in = np.ones(3)
+    a_wrong_in[2] = np.nan
+
+    assert np.all(
+        np.isnan(
+            compare_numba_vs_python(
+                transfer_function_convolver, pulse_in, a_wrong_in, b_in
+            )
+        )
+    )
+
+    # ensure that if there is a nan in b_in, all nans are outputted
+    b_wrong_in = np.ones(3)
+    b_wrong_in[2] = np.nan
+
+    assert np.all(
+        np.isnan(
+            compare_numba_vs_python(
+                transfer_function_convolver, pulse_in, a_in, b_wrong_in
+            )
+        )
+    )
+
+    # ensure that a valid input gives the expected output when comparing the pole-zero correction with the pole-zero processor
+    w_out_expected = compare_numba_vs_python(pole_zero, pulse_in, tau)
+
+    assert np.allclose(
+        compare_numba_vs_python(transfer_function_convolver, pulse_in, a_in, b_in),
+        w_out_expected,
+    )


### PR DESCRIPTION
Added a processor `transfer_function_convolver` that filters data with user-specified IIR or FIR filter coefficients.  This provides more flexibility for the user to create an arbitrary-order filter within their `dsp_config` rather than having to code a new FIR or IIR filter each time.