### PR TITLE
Fixed bug in handling of coordinates

### DIFF
--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -796,7 +796,7 @@ class ProcessingChain:
                         pd *= sl.step
 
                     off = val.offset
-                    if sl.start is not None:
+                    if sl.start is not None and sl.start>0:
                         start = sl.start * val.period
                         if isinstance(off, ProcChainVar):
                             new_off = ProcChainVar(

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -149,3 +149,41 @@ def test_processor_variable_array_output(spms_raw_tbl):
 
     proc_chain, _, _ = build_processing_chain(spms_raw_tbl, dsp_config)
     proc_chain.execute(0, 1)
+
+
+# Test that timing variables can be converted between multiple coordinate
+# grids correctly. Also tests slicing with a stride. Pickoff a time from
+# a windowed wf and a down-sampled waveform; they should be the same
+def test_proc_chain_coordinate_grid(spms_raw_tbl):
+    dsp_config = {
+        "outputs": ["a_window", "a_downsample"],
+        "processors": {
+            "a_window": {
+                "function": "fixed_time_pickoff",
+                "module": "dspeed.processors",
+                "args": [
+                    "waveform[2625:4025]",
+                    "51.2*us + waveform.offset",
+                    "'i'",
+                    "a_window"
+                ],
+                "unit": ["ADC"]
+            },
+            
+            "a_downsample": {
+                "function": "fixed_time_pickoff",
+                "module": "dspeed.processors",
+                "args": [
+                    "waveform[0:8000:8]",
+                    "51.2*us + waveform.offset",
+                    "'i'",
+                    "a_downsample"
+                ],
+                "unit": ["ADC"]
+            }
+        }
+    }
+
+    proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
+    proc_chain.execute(0, 1)
+    assert lh5_out["a_window"][0] == lh5_out["a_downsample"][0]


### PR DESCRIPTION
See https://github.com/legend-exp/dspeed/issues/18
- Added unit test to help catch cases like this
- Added fix to bug in handling of units
- Added fix to addition of quantities to coordinates (e.g. `5*us + t0`) not working if quantity comes first
- Added fix to slices adding 0 unnecessarily