### PR TITLE
Updated behavior of round operator in ProcessingChain

### DIFF
--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -935,11 +935,11 @@ class ProcessingChain:
         return var.buffer.shape[1]
 
     # round value
-    def _round(
+    def _round(  # noqa: N805
         var: ProcChainVar | Quantity,
         to_nearest: int | float | Unit | Quantity | CoordinateGrid = 1,
         dtype: str = None,
-    ) -> float | Quantity | ProcChainVar:  # noqa: N805
+    ) -> float | Quantity | ProcChainVar:
         """Round a variable or value to nearest multiple of `to_nearest`.
         If var is a ProcChainVar, and to_nearest is a Unit or Quantity, return
         a new ProcChainVar with a period of to_nearest, and the underlying

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -935,29 +935,33 @@ class ProcessingChain:
         return var.buffer.shape[1]
 
     # round value
-    def _round(var: ProcChainVar | Quantity, to_nearest: int | float | Unit | Quantity | CoordinateGrid = 1, dtype: str = None) -> float | Quantity | ProcChainVar:  # noqa: N805
+    def _round(
+        var: ProcChainVar | Quantity,
+        to_nearest: int | float | Unit | Quantity | CoordinateGrid = 1,
+        dtype: str = None,
+    ) -> float | Quantity | ProcChainVar:  # noqa: N805
         """Round a variable or value to nearest multiple of `to_nearest`.
         If var is a ProcChainVar, and to_nearest is a Unit or Quantity, return
         a new ProcChainVar with a period of to_nearest, and the underlying
         values and offset rounded. If var is a ProcChainVar and to_nearest
         is an int or a float, keep the unit and just round the underlying
         value.
-        
+
         Example usage:
         round(tp_0, wf.grid) - convert tp_0 to nearest array index of wf
         round(5*us, wf.period) - 5 us in wf clock ticks
         """
-        
+
         if var is None:
             return None
         if not isinstance(var, ProcChainVar):
-            return round(float(var/to_nearest))*to_nearest
+            return round(float(var / to_nearest)) * to_nearest
         else:
             name = f"round({var.name}, {to_nearest})"
             dtype = np.dtype(dtype) if dtype is not None else var.dtype
             if var.is_coord:
                 if isinstance(to_nearest, (int, float)):
-                    grid = CoordinateGrid(var.grid.period*to_nearest, var.grid.offset)
+                    grid = CoordinateGrid(var.grid.period * to_nearest, var.grid.offset)
                 elif isinstance(to_nearest, (Unit, Quantity)):
                     grid = CoordinateGrid(to_nearest, var.grid.offset)
                 else:
@@ -966,7 +970,7 @@ class ProcessingChain:
             else:
                 grid = var.grid
                 if isinstance(to_nearest, (int, float)):
-                    to_nearest = to_nearest*var.unit
+                    to_nearest = to_nearest * var.unit
                 conversion_manager = UnitConversionManager(var, to_nearest, round=True)
 
             out = ProcChainVar(
@@ -1333,12 +1337,14 @@ class UnitConversionManager(ProcessorManager):
             raise DSPFatal("Cannot convert to integer")
 
     @vectorize(nopython=True, cache=True)
-    def convert_round(buf_in, offset_in, offset_out, period_ratio): # noqa: N805
+    def convert_round(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return round((buf_in + offset_in) * period_ratio - offset_out)
 
     def __init__(
-        self, var: ProcChainVar, unit: str | Unit | Quantity | CoordinateGrid,
-        round = False
+        self,
+        var: ProcChainVar,
+        unit: str | Unit | Quantity | CoordinateGrid,
+        round=False,
     ) -> None:
         # reference back to our processing chain
         self.proc_chain = var.proc_chain

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -1338,7 +1338,7 @@ class UnitConversionManager(ProcessorManager):
 
     @vectorize(nopython=True, cache=True)
     def convert_round(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
-        return round((buf_in + offset_in) * period_ratio - offset_out)
+        return np.round((buf_in + offset_in) * period_ratio - offset_out)
 
     def __init__(
         self,

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -744,7 +744,7 @@ class ProcessingChain:
                 )
                 self._proc_managers.append(ProcessorManager(self, op, [operand, out]))
             else:
-                out = op(out)
+                out = op(operand)
 
             return out
 

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -935,15 +935,52 @@ class ProcessingChain:
         return var.buffer.shape[1]
 
     # round value
-    def _round(var: ProcChainVar) -> float:  # noqa: N805
+    def _round(var: ProcChainVar | Quantity, to_nearest: int | float | Unit | Quantity | CoordinateGrid = 1, dtype: str = None) -> float | Quantity | ProcChainVar:  # noqa: N805
+        """Round a variable or value to nearest multiple of `to_nearest`.
+        If var is a ProcChainVar, and to_nearest is a Unit or Quantity, return
+        a new ProcChainVar with a period of to_nearest, and the underlying
+        values and offset rounded. If var is a ProcChainVar and to_nearest
+        is an int or a float, keep the unit and just round the underlying
+        value.
+        
+        Example usage:
+        round(tp_0, wf.grid) - convert tp_0 to nearest array index of wf
+        round(5*us, wf.period) - 5 us in wf clock ticks
+        """
+        
         if var is None:
             return None
         if not isinstance(var, ProcChainVar):
-            return round(float(var))
+            return round(float(var/to_nearest))*to_nearest
         else:
-            raise ProcessingChainError(
-                "round() is not implemented for variables, only constants."
+            name = f"round({var.name}, {to_nearest})"
+            dtype = np.dtype(dtype) if dtype is not None else var.dtype
+            if var.is_coord:
+                if isinstance(to_nearest, (int, float)):
+                    grid = CoordinateGrid(var.grid.period*to_nearest, var.grid.offset)
+                elif isinstance(to_nearest, (Unit, Quantity)):
+                    grid = CoordinateGrid(to_nearest, var.grid.offset)
+                else:
+                    grid = to_nearest
+                conversion_manager = UnitConversionManager(var, grid, round=True)
+            else:
+                grid = var.grid
+                if isinstance(to_nearest, (int, float)):
+                    to_nearest = to_nearest*var.unit
+                conversion_manager = UnitConversionManager(var, to_nearest, round=True)
+
+            out = ProcChainVar(
+                var.proc_chain,
+                name,
+                var.shape,
+                dtype,
+                grid,
+                var.unit,
+                var.is_coord,
             )
+            out._buffer = conversion_manager.out_buffer
+            var.proc_chain._proc_managers.append(conversion_manager)
+            return out
 
     # type cast variable
     def _astype(var: ProcChainVar, dtype: str) -> ProcChainVar:  # noqa: N805
@@ -1295,13 +1332,20 @@ class UnitConversionManager(ProcessorManager):
         else:
             raise DSPFatal("Cannot convert to integer")
 
+    @vectorize(nopython=True, cache=True)
+    def convert_round(buf_in, offset_in, offset_out, period_ratio): # noqa: N805
+        return round((buf_in + offset_in) * period_ratio - offset_out)
+
     def __init__(
-        self, var: ProcChainVar, unit: str | Unit | Quantity | CoordinateGrid
+        self, var: ProcChainVar, unit: str | Unit | Quantity | CoordinateGrid,
+        round = False
     ) -> None:
         # reference back to our processing chain
         self.proc_chain = var.proc_chain
         # callable function used to process data
-        if np.issubdtype(var.dtype, np.integer):
+        if round:
+            self.processor = UnitConversionManager.convert_round
+        elif np.issubdtype(var.dtype, np.integer):
             self.processor = UnitConversionManager.convert_int
         else:
             self.processor = UnitConversionManager.convert

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -935,8 +935,8 @@ class ProcessingChain:
         return var.buffer.shape[1]
 
     # round value
-    def _round(  # noqa: N805
-        var: ProcChainVar | Quantity,
+    def _round(
+        var: ProcChainVar | Quantity,  # noqa: N805
         to_nearest: int | float | Unit | Quantity | CoordinateGrid = 1,
         dtype: str = None,
     ) -> float | Quantity | ProcChainVar:

--- a/tests/configs/icpc-dsp-config.json
+++ b/tests/configs/icpc-dsp-config.json
@@ -137,7 +137,7 @@
       "module": "dspeed.processors",
       "args": [
         "wf_etrap",
-        "tp_0_est+db.etrap.rise+db.etrap.flat*db.etrap.sample",
+        "round(tp_0_est+db.etrap.rise+db.etrap.flat*db.etrap.sample, wf_etrap.grid)",
         "'l'",
         "trapEftp"
       ],


### PR DESCRIPTION
round now takes two optional arguments
- to_nearest: instead of rounding to nearest integer, round to nearest arbitrary value (including units and coordinate systems). This enables the use of unitted quantities in rounding (if to_nearest has the same unit).
- dtype: control dtype of output

round is now also capable of working on processing chain variables. For coordinate-like variables (like timepoints) the recommended usage is `round(tp, wf.grid)`, which will make the internal buffer for the timepoint fall on integer multiples of the coordinate space; this is optimal for any processor that expects integer values.