### PR TITLE
Added unit for astype and round; fixed bugs in each

### DIFF
--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -23,8 +23,8 @@ from numba import vectorize
 from pint import Quantity, Unit
 
 from .errors import DSPFatal, ProcessingChainError
-from .units import unit_registry as ureg
 from .processors.round_to_nearest import round_to_nearest
+from .units import unit_registry as ureg
 from .utils import ProcChainVarBase
 
 log = logging.getLogger(__name__)
@@ -1333,15 +1333,20 @@ class ProcessorManager:
 class UnitConversionManager(ProcessorManager):
     """A special processor manager for handling converting variables between unit systems."""
 
-    @vectorize([f"{t}({t}, f8, f8, f8)" for t in ["f4", "f8"]],
-               nopython=True, cache=True
-               )
+    @vectorize(
+        [f"{t}({t}, f8, f8, f8)" for t in ["f4", "f8"]], nopython=True, cache=True
+    )
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return (buf_in + offset_in) * period_ratio - offset_out
 
-    @vectorize([f"{t}({t}, f8, f8, f8)" for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8"]],
-               nopython=True, cache=True
-               )
+    @vectorize(
+        [
+            f"{t}({t}, f8, f8, f8)"
+            for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8"]
+        ],
+        nopython=True,
+        cache=True,
+    )
     def convert_int(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         tmp = (buf_in + offset_in) * period_ratio - offset_out
         ret = np.rint(tmp)
@@ -1350,7 +1355,14 @@ class UnitConversionManager(ProcessorManager):
         else:
             raise DSPFatal("Cannot convert to integer. Use round or astype")
 
-    @vectorize([f"{t}({t}, f8, f8, f8)" for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8", "f4", "f8"]], nopython=True, cache=True)
+    @vectorize(
+        [
+            f"{t}({t}, f8, f8, f8)"
+            for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8", "f4", "f8"]
+        ],
+        nopython=True,
+        cache=True,
+    )
     def convert_round(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return np.rint((buf_in + offset_in) * period_ratio - offset_out)
 
@@ -1396,7 +1408,7 @@ class UnitConversionManager(ProcessorManager):
             ratio = float(from_unit / unit)
             from_offset = 0
         else:
-            ratio = 1/unit
+            ratio = 1 / unit
             from_offset = 0
 
         self.out_buffer = np.zeros_like(from_buffer, dtype=var.dtype)
@@ -1786,7 +1798,7 @@ def build_processing_chain(
 
         # find DB lookups in args and replace the values
         if isinstance(node, str):
-            node = { "function": node }
+            node = {"function": node}
             processors[key] = node
         if "args" in node:
             args = node["args"]
@@ -1925,12 +1937,12 @@ def build_processing_chain(
                         f"Could not find function {recipe['function']}"
                     )
                 new_var = proc_chain.add_variable(
-                    name     = proc_par,
-                    dtype    = fun_var.dtype,
-                    shape    = fun_var.shape,
-                    grid     = fun_var.grid,
-                    unit     = fun_var.unit,
-                    is_coord = fun_var.is_coord,
+                    name=proc_par,
+                    dtype=fun_var.dtype,
+                    shape=fun_var.shape,
+                    grid=fun_var.grid,
+                    unit=fun_var.unit,
+                    is_coord=fun_var.is_coord,
                 )
                 new_var._buffer = fun_var._buffer
                 log.debug(f"setting {new_var} = {fun_var}")

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -24,6 +24,7 @@ from pint import Quantity, Unit
 
 from .errors import DSPFatal, ProcessingChainError
 from .units import unit_registry as ureg
+from .utils import ProcChainVarBase
 
 log = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ class CoordinateGrid:
         return f"({str(self.period)},{offset})"
 
 
-class ProcChainVar:
+class ProcChainVar(ProcChainVarBase):
     """Helper data class with buffer and information for internal variables in
     :class:`ProcessingChain`.
 

--- a/src/dspeed/processors/__init__.py
+++ b/src/dspeed/processors/__init__.py
@@ -85,6 +85,7 @@ from .peak_snr_threshold import peak_snr_threshold
 from .pole_zero import double_pole_zero, pole_zero
 from .presum import presum
 from .pulse_injector import inject_exp_pulse, inject_sig_pulse
+from .round_to_nearest import round_to_nearest
 from .saturation import saturation
 from .soft_pileup_corr import soft_pileup_corr, soft_pileup_corr_bl
 from .time_over_threshold import time_over_threshold
@@ -144,4 +145,5 @@ __all__ = [
     "time_over_threshold",
     "dplms",
     "moving_slope",
+    "round_to_nearest",
 ]

--- a/src/dspeed/processors/fftw.py
+++ b/src/dspeed/processors/fftw.py
@@ -6,11 +6,13 @@ import numpy as np
 from numba import guvectorize
 from pyfftw import FFTW
 
-from ..utils import numba_defaults_kwargs as nb_kwargs
 from ..utils import ProcChainVarBase
+from ..utils import numba_defaults_kwargs as nb_kwargs
 
 
-def dft(w_in: np.ndarray | ProcChainVarBase, w_out: np.ndarray | ProcChainVarBase) -> Callable:
+def dft(
+    w_in: np.ndarray | ProcChainVarBase, w_out: np.ndarray | ProcChainVarBase
+) -> Callable:
     """Perform discrete Fourier transforms using the FFTW library.
 
     Parameters

--- a/src/dspeed/processors/fftw.py
+++ b/src/dspeed/processors/fftw.py
@@ -6,11 +6,11 @@ import numpy as np
 from numba import guvectorize
 from pyfftw import FFTW
 
-from ..processing_chain import ProcChainVar
 from ..utils import numba_defaults_kwargs as nb_kwargs
+from ..utils import ProcChainVarBase
 
 
-def dft(w_in: np.ndarray | ProcChainVar, w_out: np.ndarray | ProcChainVar) -> Callable:
+def dft(w_in: np.ndarray | ProcChainVarBase, w_out: np.ndarray | ProcChainVarBase) -> Callable:
     """Perform discrete Fourier transforms using the FFTW library.
 
     Parameters
@@ -55,7 +55,7 @@ def dft(w_in: np.ndarray | ProcChainVar, w_out: np.ndarray | ProcChainVar) -> Ca
     =============================== ========= =============================== =============
     """
     # if we have a ProcChainVar, set up the output and get numpy arrays
-    if isinstance(w_in, ProcChainVar) and isinstance(w_out, ProcChainVar):
+    if isinstance(w_in, ProcChainVarBase) and isinstance(w_out, ProcChainVarBase):
         c = w_in.dtype.kind
         s = w_in.dtype.itemsize
         if c == "f":
@@ -143,7 +143,7 @@ def inv_dft(w_in: np.ndarray, w_out: np.ndarray) -> Callable:
     =============================== ============= =============================== =========
     """
     # if we have a ProcChainVar, set up the output and get numpy arrays
-    if isinstance(w_in, ProcChainVar) and isinstance(w_out, ProcChainVar):
+    if isinstance(w_in, ProcChainVarBase) and isinstance(w_out, ProcChainVarBase):
         s = w_in.dtype.itemsize
         if w_out.dtype == "auto":
             w_out.update_auto(
@@ -231,7 +231,7 @@ def psd(w_in: np.ndarray, w_out: np.ndarray) -> Callable:
     =============================== ========= ============================ =============
     """
     # if we have a ProcChainVar, set up the output and get numpy arrays
-    if isinstance(w_in, ProcChainVar) and isinstance(w_out, ProcChainVar):
+    if isinstance(w_in, ProcChainVarBase) and isinstance(w_out, ProcChainVarBase):
         c = w_in.dtype.kind
         s = w_in.dtype.itemsize
         if c == "f":

--- a/src/dspeed/processors/round_to_nearest.py
+++ b/src/dspeed/processors/round_to_nearest.py
@@ -5,17 +5,19 @@ from numba import guvectorize
 
 from ..utils import numba_defaults_kwargs as nb_kwargs
 
+
 @guvectorize(
-    [ f"void({t}, {t}, {t}[:])" for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8", "f4", "f8"] ],
+    [
+        f"void({t}, {t}, {t}[:])"
+        for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8", "f4", "f8"]
+    ],
     "(),()->()",
     nopython=True,
     **nb_kwargs,
 )
-def round_to_nearest(
-        val: np.ndarray, to_nearest: int | float, out: np.ndarray
-) -> None:
+def round_to_nearest(val: np.ndarray, to_nearest: int | float, out: np.ndarray) -> None:
     """Round value to nearest multiple of to_nearest.
-    
+
     Parameters
     ----------
     val
@@ -24,14 +26,14 @@ def round_to_nearest(
         round to multiple of this
     out
         rounded value
-    
+
     JSON Configuration Example
     --------------------------
-    
+
     Note: this processor is aliased using `round` in ProcessingChain.
     The following two examples are equivalent.
     .. code-block :: json
-    
+
         "t_rounded": {
             "function": "round_to_nearest",
             "module": "dspeed.processors",
@@ -44,4 +46,4 @@ def round_to_nearest(
     if np.isnan(val):
         out[:] = np.nan
     else:
-        out[:] = to_nearest*round(val/to_nearest)
+        out[:] = to_nearest * round(val / to_nearest)

--- a/src/dspeed/processors/round_to_nearest.py
+++ b/src/dspeed/processors/round_to_nearest.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import numpy as np
+from numba import guvectorize
+
+from ..utils import numba_defaults_kwargs as nb_kwargs
+
+@guvectorize(
+    [ f"void({t}, {t}, {t}[:])" for t in ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8", "f4", "f8"] ],
+    "(),()->()",
+    nopython=True,
+    **nb_kwargs,
+)
+def round_to_nearest(
+        val: np.ndarray, to_nearest: int | float, out: np.ndarray
+) -> None:
+    """Round value to nearest multiple of to_nearest.
+    
+    Parameters
+    ----------
+    val
+        value to be rounded
+    to_nearest
+        round to multiple of this
+    out
+        rounded value
+    
+    JSON Configuration Example
+    --------------------------
+    
+    Note: this processor is aliased using `round` in ProcessingChain.
+    The following two examples are equivalent.
+    .. code-block :: json
+    
+        "t_rounded": {
+            "function": "round_to_nearest",
+            "module": "dspeed.processors",
+            "args": ["t_in", "1*us", "t_rounded"]
+            "unit": ["ns"]
+        },
+        "t_rounded": "round(t_in, 1*us)"
+    """
+
+    if np.isnan(val):
+        out[:] = np.nan
+    else:
+        out[:] = to_nearest*round(val/to_nearest)

--- a/src/dspeed/processors/round_to_nearest.py
+++ b/src/dspeed/processors/round_to_nearest.py
@@ -16,7 +16,8 @@ from ..utils import numba_defaults_kwargs as nb_kwargs
     **nb_kwargs,
 )
 def round_to_nearest(val: np.ndarray, to_nearest: int | float, out: np.ndarray) -> None:
-    """Round value to nearest multiple of to_nearest.
+    """
+    Round value to nearest multiple of to_nearest.
 
     Parameters
     ----------
@@ -32,6 +33,7 @@ def round_to_nearest(val: np.ndarray, to_nearest: int | float, out: np.ndarray) 
 
     Note: this processor is aliased using `round` in ProcessingChain.
     The following two examples are equivalent.
+
     .. code-block :: json
 
         "t_rounded": {

--- a/src/dspeed/utils.py
+++ b/src/dspeed/utils.py
@@ -1,6 +1,7 @@
 import os
 from collections.abc import MutableMapping
 from typing import Any, Iterator
+from abc import ABCMeta
 
 
 def getenv_bool(name: str, default: bool = False) -> bool:
@@ -77,3 +78,12 @@ class NumbaDefaults(MutableMapping):
 
 numba_defaults = NumbaDefaults()
 numba_defaults_kwargs = numba_defaults
+
+
+class ProcChainVarBase(metaclass=ABCMeta):
+    r"""Base class.
+    
+    :class:`ProcChainVar` implements this class. This base class is used
+    by processors that use ProcChainVar in their contructors.
+    """
+    pass

--- a/src/dspeed/utils.py
+++ b/src/dspeed/utils.py
@@ -1,7 +1,7 @@
 import os
+from abc import ABCMeta
 from collections.abc import MutableMapping
 from typing import Any, Iterator
-from abc import ABCMeta
 
 
 def getenv_bool(name: str, default: bool = False) -> bool:
@@ -82,7 +82,7 @@ numba_defaults_kwargs = numba_defaults
 
 class ProcChainVarBase(metaclass=ABCMeta):
     r"""Base class.
-    
+
     :class:`ProcChainVar` implements this class. This base class is used
     by processors that use ProcChainVar in their contructors.
     """

--- a/src/dspeed/utils.py
+++ b/src/dspeed/utils.py
@@ -84,6 +84,6 @@ class ProcChainVarBase(metaclass=ABCMeta):
     r"""Base class.
 
     :class:`ProcChainVar` implements this class. This base class is used
-    by processors that use ProcChainVar in their contructors.
+    by processors that use ProcChainVar in their constructors.
     """
     pass

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -1,5 +1,6 @@
 import lgdo
 import pytest
+import numpy as np
 
 from dspeed.processing_chain import build_processing_chain
 
@@ -186,3 +187,28 @@ def test_proc_chain_coordinate_grid(spms_raw_tbl):
     proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
     proc_chain.execute(0, 1)
     assert lh5_out["a_window"][0] == lh5_out["a_downsample"][0]
+
+def test_proc_chain_round(spms_raw_tbl):
+    dsp_config = {
+        "outputs": ["waveform_round"],
+        "processors": {
+            "waveform_round": "round(waveform, 4)"
+        }
+    }
+
+    proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
+    proc_chain.execute(0, 1)
+    assert(np.all(np.rint(spms_raw_tbl["waveform"].values[0]/4)*4 == lh5_out["waveform_round"].values[0]))
+
+def test_proc_chain_as_type(spms_raw_tbl):
+    dsp_config = {
+        "outputs": ["waveform_32"],
+        "processors": {
+            "waveform_32": "astype(waveform, 'float32')"
+        }
+    }
+
+    proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
+    proc_chain.execute(0, 1)
+    assert(np.all(spms_raw_tbl["waveform"].values[0] == lh5_out["waveform_32"].values[0]))
+

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -1,6 +1,6 @@
 import lgdo
-import pytest
 import numpy as np
+import pytest
 
 from dspeed.processing_chain import build_processing_chain
 
@@ -188,27 +188,29 @@ def test_proc_chain_coordinate_grid(spms_raw_tbl):
     proc_chain.execute(0, 1)
     assert lh5_out["a_window"][0] == lh5_out["a_downsample"][0]
 
+
 def test_proc_chain_round(spms_raw_tbl):
     dsp_config = {
         "outputs": ["waveform_round"],
-        "processors": {
-            "waveform_round": "round(waveform, 4)"
-        }
+        "processors": {"waveform_round": "round(waveform, 4)"},
     }
 
     proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
     proc_chain.execute(0, 1)
-    assert(np.all(np.rint(spms_raw_tbl["waveform"].values[0]/4)*4 == lh5_out["waveform_round"].values[0]))
+    assert np.all(
+        np.rint(spms_raw_tbl["waveform"].values[0] / 4) * 4
+        == lh5_out["waveform_round"].values[0]
+    )
+
 
 def test_proc_chain_as_type(spms_raw_tbl):
     dsp_config = {
         "outputs": ["waveform_32"],
-        "processors": {
-            "waveform_32": "astype(waveform, 'float32')"
-        }
+        "processors": {"waveform_32": "astype(waveform, 'float32')"},
     }
 
     proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
     proc_chain.execute(0, 1)
-    assert(np.all(spms_raw_tbl["waveform"].values[0] == lh5_out["waveform_32"].values[0]))
-
+    assert np.all(
+        spms_raw_tbl["waveform"].values[0] == lh5_out["waveform_32"].values[0]
+    )


### PR DESCRIPTION
See issue https://github.com/legend-exp/dspeed/issues/17

Also made it so that ProcessingChain operators such as astype, round, and binary and unary operators can be used directly as the function in the json config files by not providing args. Example:
```
"processors": {
    "example": {
        "function": "round(a)"
        ...
   }
```
For very simple cases one can also do:
```
"processors": {
    "simpler_example": "a+b"
}
```