### PR TITLE
Fixed bug in handling of constant parameters

### DIFF
--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -264,6 +264,7 @@ class ProcChainVar(ProcChainVarBase):
         conversion_manager = UnitConversionManager(self, unit)
         self._buffer.append((conversion_manager.out_buffer, unit))
         self.proc_chain._proc_managers.append(conversion_manager)
+        log.debug(f"added conversion: {conversion_manager}")
         return conversion_manager.out_buffer
 
     @property
@@ -471,7 +472,7 @@ class ProcessingChain:
             unit=unit,
         )
         np.copyto(param.get_buffer(), val, casting="unsafe")
-        log.debug(f"set constant: {self.description()} = {val}")
+        log.debug(f"set constant: {param.description()} = {val}")
         return param
 
     def link_input_buffer(
@@ -632,6 +633,7 @@ class ProcessingChain:
 
         proc_man = ProcessorManager(self, func, params, kw_params, signature, types)
         self._proc_managers.append(proc_man)
+        log.debug(f"added processor: {proc_man}")
 
     def execute(self, start: int = 0, stop: int = None) -> None:
         """Execute the dsp chain on the entire input/output buffers."""
@@ -786,7 +788,9 @@ class ProcessingChain:
                     is_coord=rhs.is_coord,
                 )
 
-            self._proc_managers.append(ProcessorManager(self, op, [lhs, rhs, out]))
+            proc_man = ProcessorManager(self, op, [lhs, rhs, out])
+            self._proc_managers.append(proc_man)
+            log.debug(f"added processor: {proc_man}")
             return out
 
         # define unary operators (-)
@@ -807,7 +811,9 @@ class ProcessingChain:
                     operand.unit,
                     operand.is_coord,
                 )
-                self._proc_managers.append(ProcessorManager(self, op, [operand, out]))
+                proc_man = ProcessorManager(self, op, [operand, out])
+                self._proc_managers.append(proc_man)
+                log.debug(f"added processor: {proc_man}")
             else:
                 out = op(operand)
 
@@ -869,9 +875,9 @@ class ProcessingChain:
                             new_off = ProcChainVar(
                                 self, name=f"({str(off)}+{str(start)})", is_coord=True
                             )
-                            self._proc_managers.append(
-                                ProcessorManager(self, np.add, [off, start, new_off])
-                            )
+                            proc_man = ProcessorManager(self, np.add, [off, start, new_off])
+                            self._proc_managers.append(proc_man)
+                            log.debug(f"added processor: {proc_man}")
                             off = new_off
                         else:
                             off += start
@@ -1047,6 +1053,7 @@ class ProcessingChain:
                 conversion_manager = UnitConversionManager(var, grid, round=True)
                 out._buffer = conversion_manager.out_buffer
                 var.proc_chain._proc_managers.append(conversion_manager)
+                log.debug(f"added conversion: {conversion_manager}")
             else:
                 out = ProcChainVar(
                     var.proc_chain,
@@ -1080,16 +1087,16 @@ class ProcessingChain:
                 var.unit,
                 var.is_coord,
             )
-            var.proc_chain._proc_managers.append(
-                ProcessorManager(
-                    var.proc_chain,
-                    np.copyto,
-                    [out, var],
-                    kw_params={"casting": "'unsafe'"},
-                    signature="(),(),()",
-                    types=f"{dtype.char}{var.dtype.char}",
-                )
+            proc_man = ProcessorManager(
+                var.proc_chain,
+                np.copyto,
+                [out, var],
+                kw_params={"casting": "'unsafe'"},
+                signature="(),(),()",
+                types=f"{dtype.char}{var.dtype.char}",
             )
+            var.proc_chain._proc_managers.append(proc_man)
+            log.debug(f"added processor: {proc_man}")
             return out
 
     def _loadlh5(path_to_file, path_in_file: str) -> np.array:  # noqa: N805
@@ -1403,8 +1410,6 @@ class ProcessorManager:
             else:
                 self.kwargs[arg_name] = param
 
-        log.debug(f"added processor: {self}")
-
     def execute(self) -> None:
         self.processor(*self.args, **self.kwargs)
 
@@ -1510,8 +1515,6 @@ class UnitConversionManager(ProcessorManager):
             self.out_buffer,
         ]
         self.kwargs = {}
-
-        log.debug(f"added conversion: {self}")
 
 
 class IOManager(metaclass=ABCMeta):
@@ -2152,7 +2155,7 @@ def build_processing_chain(
         buf_in = lh5_in.get(copy_par)
         if buf_in is None:
             log.warning(
-                f"I don't know what to do with {copy_par}. Building output without it!"
+                f"Did not find {copy_par} in either input file or parameter list. Building output without it!"
             )
         else:
             lh5_out.add_field(copy_par, buf_in)

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -875,7 +875,9 @@ class ProcessingChain:
                             new_off = ProcChainVar(
                                 self, name=f"({str(off)}+{str(start)})", is_coord=True
                             )
-                            proc_man = ProcessorManager(self, np.add, [off, start, new_off])
+                            proc_man = ProcessorManager(
+                                self, np.add, [off, start, new_off]
+                            )
                             self._proc_managers.append(proc_man)
                             log.debug(f"added processor: {proc_man}")
                             off = new_off
@@ -2106,7 +2108,7 @@ def build_processing_chain(
             params = []
             kw_params = {}
             out_params = []
-            is_const=True
+            is_const = True
             for param in args:
                 if isinstance(param, str):
                     param = proc_chain.get_variable(param)
@@ -2138,7 +2140,9 @@ def build_processing_chain(
                     )
                     proc_man.execute()
                     for param in out_params:
-                        log.debug(f"set constant: {param.description()} = {param.get_buffer()}")
+                        log.debug(
+                            f"set constant: {param.description()} = {param.get_buffer()}"
+                        )
 
                 else:
                     const_val = func(*params, **kw_params)

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -215,7 +215,7 @@ class ProcChainVar(ProcChainVarBase):
             if self.is_const
             else (self.proc_chain._block_width,) + self.shape
         )
-        len = np.product(shape)
+        len = np.prod(shape)
         # Flattened array, with padding to allow memory alignment
         buf = np.zeros(len + 64 // self.dtype.itemsize, dtype=self.dtype)
         # offset to ensure memory alignment

--- a/src/dspeed/processors/convolutions.py
+++ b/src/dspeed/processors/convolutions.py
@@ -15,7 +15,6 @@ from ..utils import numba_defaults_kwargs as nb_kwargs
     ],
     "(n),(m),(),(p)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )
@@ -71,7 +70,6 @@ def convolve_wf(
     ],
     "(n),(m),(),(p)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )

--- a/src/dspeed/processors/convolutions.py
+++ b/src/dspeed/processors/convolutions.py
@@ -48,10 +48,16 @@ def convolve_wf(
 
     if chr(mode_in) == "f":
         mode = "full"
+        if len(w_out) != len(w_in) + len(kernel) - 1:
+            raise DSPFatal(f"Output waveform has length {len(w_out)}; expect {len(w_in) + len(kernel) - 1}")
     elif chr(mode_in) == "v":
         mode = "valid"
+        if len(w_out) != abs(len(w_in) - len(kernel)) + 1:
+            raise DSPFatal(f"Output waveform has length {len(w_out)}; expect {abs(len(w_in) - len(kernel)) + 1}")
     elif chr(mode_in) == "s":
         mode = "same"
+        if len(w_out) != max(len(w_in), len(kernel)):
+            raise DSPFatal("Output waveform has length {len(w_out)}; expect {max(len(w_in), len(kernel))}")
     else:
         raise DSPFatal("Invalid mode")
 

--- a/src/dspeed/processors/convolutions.py
+++ b/src/dspeed/processors/convolutions.py
@@ -48,15 +48,21 @@ def convolve_wf(
     if chr(mode_in) == "f":
         mode = "full"
         if len(w_out) != len(w_in) + len(kernel) - 1:
-            raise DSPFatal(f"Output waveform has length {len(w_out)}; expect {len(w_in) + len(kernel) - 1}")
+            raise DSPFatal(
+                f"Output waveform has length {len(w_out)}; expect {len(w_in) + len(kernel) - 1}"
+            )
     elif chr(mode_in) == "v":
         mode = "valid"
         if len(w_out) != abs(len(w_in) - len(kernel)) + 1:
-            raise DSPFatal(f"Output waveform has length {len(w_out)}; expect {abs(len(w_in) - len(kernel)) + 1}")
+            raise DSPFatal(
+                f"Output waveform has length {len(w_out)}; expect {abs(len(w_in) - len(kernel)) + 1}"
+            )
     elif chr(mode_in) == "s":
         mode = "same"
         if len(w_out) != max(len(w_in), len(kernel)):
-            raise DSPFatal("Output waveform has length {len(w_out)}; expect {max(len(w_in), len(kernel))}")
+            raise DSPFatal(
+                "Output waveform has length {len(w_out)}; expect {max(len(w_in), len(kernel))}"
+            )
     else:
         raise DSPFatal("Invalid mode")
 

--- a/src/dspeed/processors/energy_kernels.py
+++ b/src/dspeed/processors/energy_kernels.py
@@ -14,7 +14,6 @@ from ..utils import numba_defaults_kwargs as nb_kwargs
     ],
     "(),(),(),(n)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )
@@ -77,7 +76,6 @@ def cusp_filter(sigma: float, flat: int, decay: int, kernel: np.array) -> None:
     ],
     "(),(),(),(n)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )
@@ -160,7 +158,6 @@ def zac_filter(sigma: float, flat: int, decay: int, kernel: np.array) -> None:
     ],
     "(n,n),(m),(),(),(),(),(n)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )

--- a/src/dspeed/processors/gaussian_filter1d.py
+++ b/src/dspeed/processors/gaussian_filter1d.py
@@ -92,7 +92,6 @@ def gaussian_filter1d(sigma: int, truncate: float = 4.0) -> numpy.ndarray:
         ],
         "(n),(m)",
         **nb_kwargs(
-            cache=False,
             forceobj=True,
         ),
     )

--- a/src/dspeed/processors/kernels.py
+++ b/src/dspeed/processors/kernels.py
@@ -11,7 +11,6 @@ from ..utils import numba_defaults_kwargs as nb_kwargs
     ["void(float32, float32, float32[:])", "void(float64, float64, float64[:])"],
     "(),(),(n)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )
@@ -58,7 +57,6 @@ def t0_filter(rise: int, fall: int, kernel: np.array) -> None:
     ["void(float32[:])", "void(float64[:])"],
     "(n)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )
@@ -98,7 +96,6 @@ def moving_slope(kernel):
     ["void(float32, float32[:])", "void(float64, float64[:])"],
     "(),(n)",
     **nb_kwargs(
-        cache=False,
         forceobj=True,
     ),
 )


### PR DESCRIPTION
Changed how build_processing_chain was figuring out which parameters to treat as constants. Also
- Improved logging in processing chain
- Cache convolution related functions
- Convolve now raises errors when output array is wrong size