### PR TITLE
Default numba cache to true

### DIFF
--- a/src/dspeed/utils.py
+++ b/src/dspeed/utils.py
@@ -46,7 +46,7 @@ class NumbaDefaults(MutableMapping):
     """
 
     def __init__(self) -> None:
-        self.cache: bool = getenv_bool("DSPEED_CACHE")
+        self.cache: bool = getenv_bool("DSPEED_CACHE", default=True)
         self.boundscheck: bool = getenv_bool("DSPEED_BOUNDSCHECK")
 
     def __getitem__(self, item: str) -> Any:


### PR DESCRIPTION
See https://github.com/legend-exp/dspeed/issues/16. This will vastly speed up import of dspeed (after the first time). Caching can still be disabled for individual processors using the default_kwargs interface, or setting the `DSPEED_CACHE` environment variable to 0 or false (actually anything other than 1, t or true).