### PR TITLE
Added ability to set LGDO attributes through `build_dsp()`

### DIFF
--- a/src/dspeed/build_dsp.py
+++ b/src/dspeed/build_dsp.py
@@ -46,8 +46,10 @@ def build_dsp(
         :class:`~.processing_chain.ProcessingChain` config. See
         :func:`~.processing_chain.build_processing_chain` for details.
     lh5_tables
-        list of HDF5 groups to consider in the input file. If ``None``, process
-        all valid groups.
+        list of LGDO groups to process in the input file. These table should
+        include all input variables for processing or contain a subgroup
+        called raw that contains such a table. If ``None``, process
+        all valid groups. Note that wildcards are accepted (e.g. "ch*").
     database
         dictionary or name of JSON file containing a parameter database. See
         :func:`~.processing_chain.build_processing_chain` for details.

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -2340,9 +2340,7 @@ def build_processing_chain(
             recipe = processors[out_par]
             if isinstance(recipe, str):
                 recipe = processors[recipe]
-            buf_out.attrs.update(
-                recipe.get("lh5_attrs", {})
-            )
+            buf_out.attrs.update(recipe.get("lh5_attrs", {}))
             lh5_out.add_field(out_par, buf_out)
         except Exception as e:
             raise ProcessingChainError(

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -2337,6 +2337,12 @@ def build_processing_chain(
     for out_par in out_par_list:
         try:
             buf_out = proc_chain.link_output_buffer(out_par)
+            recipe = processors[out_par]
+            if isinstance(recipe, str):
+                recipe = processors[recipe]
+            buf_out.attrs.update(
+                recipe.get("lh5_attrs", {})
+            )
             lh5_out.add_field(out_par, buf_out)
         except Exception as e:
             raise ProcessingChainError(

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -58,9 +58,11 @@ class WaveformBrowser:
             also pass an LH5Iterator
 
         lh5_group
-            HDF5 group(s) to read. If a list is provided for both lh5_files
+            HDF5 base group(s) to read containing a LGDO table that contains
+            the waveforms. If a list is provided for both lh5_files
             and group, they must be the same size. If a file is wild-carded,
             the same group will be assigned to each file found
+
         base_path
             base path for file. See :class:`~lgdo.lh5.LH5Store`.
 

--- a/tests/processors/test_histogram.py
+++ b/tests/processors/test_histogram.py
@@ -28,7 +28,8 @@ def test_histogram_fixed_width(lgnd_test_data, tmptestdir):
     )
     assert os.path.exists(dsp_file)
 
-    df = lh5.load_nda(dsp_file, ["hist_weights", "hist_borders"], "geds/dsp/")
+    st = lh5.LH5Store()
+    df = st.read("geds/dsp/", dsp_file, field_mask=["hist_weights", "hist_borders"])[0].view_as('pd')
 
     assert len(df["hist_weights"][0]) + 1 == len(df["hist_borders"][0])
     for i in range(2, len(df["hist_borders"][0])):

--- a/tests/processors/test_histogram.py
+++ b/tests/processors/test_histogram.py
@@ -29,7 +29,9 @@ def test_histogram_fixed_width(lgnd_test_data, tmptestdir):
     assert os.path.exists(dsp_file)
 
     st = lh5.LH5Store()
-    df = st.read("geds/dsp/", dsp_file, field_mask=["hist_weights", "hist_borders"])[0].view_as('pd')
+    df = st.read("geds/dsp/", dsp_file, field_mask=["hist_weights", "hist_borders"])[
+        0
+    ].view_as("pd")
 
     assert len(df["hist_weights"][0]) + 1 == len(df["hist_borders"][0])
     for i in range(2, len(df["hist_borders"][0])):

--- a/tests/test_list_parsing.py
+++ b/tests/test_list_parsing.py
@@ -33,6 +33,8 @@ def test_list_parsing(lgnd_test_data, tmptestdir):
     assert os.path.exists(dsp_file)
 
     st = lh5.LH5Store()
-    df = st.read("geds/dsp/", dsp_file, n_rows=5, field_mask=["wf_out"])[0].view_as('pd')
+    df = st.read("geds/dsp/", dsp_file, n_rows=5, field_mask=["wf_out"])[0].view_as(
+        "pd"
+    )
 
     assert np.all(df["wf_out"][:] == np.array([7, 9, 11, 13, 15]))

--- a/tests/test_list_parsing.py
+++ b/tests/test_list_parsing.py
@@ -9,7 +9,7 @@ from dspeed import build_dsp
 config_dir = Path(__file__).parent / "configs"
 
 
-def test_list_parsng(lgnd_test_data, tmptestdir):
+def test_list_parsing(lgnd_test_data, tmptestdir):
     dsp_file = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
     dsp_config = {
         "outputs": ["wf_out"],
@@ -32,6 +32,7 @@ def test_list_parsng(lgnd_test_data, tmptestdir):
     )
     assert os.path.exists(dsp_file)
 
-    df = lh5.load_nda(dsp_file, ["wf_out"], "geds/dsp/")
+    st = lh5.LH5Store()
+    df = st.read("geds/dsp/", dsp_file, n_rows=5, field_mask=["wf_out"])[0].view_as('pd')
 
     assert np.all(df["wf_out"][:] == np.array([7, 9, 11, 13, 15]))

--- a/tests/test_numpy_constants_parsing.py
+++ b/tests/test_numpy_constants_parsing.py
@@ -24,7 +24,8 @@ def test_build_dsp(lgnd_test_data, tmptestdir):
 
 def test_numpy_math_constants_dsp(tmptestdir):
     dsp_file = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
-    df = lh5.load_nda(dsp_file, ["timestamp", "calc1", "calc2", "calc3"], "geds/dsp/")
+    st = lh5.LH5Store()
+    df = st.read("geds/dsp/", dsp_file, field_mask=["timestamp", "calc1", "calc2", "calc3"])[0].view_as('pd')
 
     a1 = df["timestamp"] - df["timestamp"] - np.pi * df["timestamp"]
     a2 = df["timestamp"] - df["timestamp"] - np.pi
@@ -41,7 +42,8 @@ def test_numpy_math_constants_dsp(tmptestdir):
 
 def test_numpy_infinity_and_nan_dsp(tmptestdir):
     dsp_file = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
-    df = lh5.load_nda(dsp_file, ["calc4", "calc5", "calc6"], "geds/dsp/")
+    st = lh5.LH5Store()
+    df = st.read("geds/dsp/", dsp_file, field_mask=["calc4", "calc5", "calc6"])[0].view_as('pd')
 
     assert (np.isnan(df["calc4"])).all()
     assert (np.isneginf(df["calc5"])).all()

--- a/tests/test_numpy_constants_parsing.py
+++ b/tests/test_numpy_constants_parsing.py
@@ -25,7 +25,9 @@ def test_build_dsp(lgnd_test_data, tmptestdir):
 def test_numpy_math_constants_dsp(tmptestdir):
     dsp_file = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
     st = lh5.LH5Store()
-    df = st.read("geds/dsp/", dsp_file, field_mask=["timestamp", "calc1", "calc2", "calc3"])[0].view_as('pd')
+    df = st.read(
+        "geds/dsp/", dsp_file, field_mask=["timestamp", "calc1", "calc2", "calc3"]
+    )[0].view_as("pd")
 
     a1 = df["timestamp"] - df["timestamp"] - np.pi * df["timestamp"]
     a2 = df["timestamp"] - df["timestamp"] - np.pi
@@ -43,7 +45,9 @@ def test_numpy_math_constants_dsp(tmptestdir):
 def test_numpy_infinity_and_nan_dsp(tmptestdir):
     dsp_file = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
     st = lh5.LH5Store()
-    df = st.read("geds/dsp/", dsp_file, field_mask=["calc4", "calc5", "calc6"])[0].view_as('pd')
+    df = st.read("geds/dsp/", dsp_file, field_mask=["calc4", "calc5", "calc6"])[
+        0
+    ].view_as("pd")
 
     assert (np.isnan(df["calc4"])).all()
     assert (np.isneginf(df["calc5"])).all()

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -248,3 +248,22 @@ def test_output_types(spms_raw_tbl):
     assert isinstance(lh5_out["wf_out"], lgdo.WaveformTable)
     assert isinstance(lh5_out["aoa_out"], lgdo.ArrayOfEqualSizedArrays)
     assert isinstance(lh5_out["vov_max_out"], lgdo.VectorOfVectors)
+
+def test_output_attrs(geds_raw_tbl):
+    dsp_config = {
+        "outputs": ["wf_blsub"],
+        "processors": {
+            "wf_blsub": {
+                "function": "bl_subtract",
+                "module": "dspeed.processors",
+                "args": ["waveform[0:100]", "baseline", "wf_blsub"],
+                "unit": "ADC",
+                "lh5_attrs": {
+                    "test_attr": "This is a test"
+                },
+            }
+        },
+    }
+    proc_chain, _, lh5_out = build_processing_chain(geds_raw_tbl, dsp_config)
+    proc_chain.execute(0, 1)
+    assert lh5_out["wf_blsub"].attrs["test_attr"] == "This is a test"

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -249,6 +249,7 @@ def test_output_types(spms_raw_tbl):
     assert isinstance(lh5_out["aoa_out"], lgdo.ArrayOfEqualSizedArrays)
     assert isinstance(lh5_out["vov_max_out"], lgdo.VectorOfVectors)
 
+
 def test_output_attrs(geds_raw_tbl):
     dsp_config = {
         "outputs": ["wf_blsub"],
@@ -258,9 +259,7 @@ def test_output_attrs(geds_raw_tbl):
                 "module": "dspeed.processors",
                 "args": ["waveform[0:100]", "baseline", "wf_blsub"],
                 "unit": "ADC",
-                "lh5_attrs": {
-                    "test_attr": "This is a test"
-                },
+                "lh5_attrs": {"test_attr": "This is a test"},
             }
         },
     }


### PR DESCRIPTION
See issue https://github.com/legend-exp/dspeed/issues/21. Does not support passing dicts as attrs, giving ```TypeError: Object dtype dtype('O') has no native HDF5 equivalent```