### PR TITLE
Changes to time_point_thresh_interpolated 

### DIFF
--- a/src/dspeed/processors/time_point_thresh.py
+++ b/src/dspeed/processors/time_point_thresh.py
@@ -157,10 +157,12 @@ def interpolated_time_point_thresh(
         for i in range(int(t_start), len(w_in) - 1, 1):
             if w_in[i] <= a_threshold < w_in[i + 1]:
                 i_cross = i
+                return
     else:
         for i in range(int(t_start), 1, -1):
             if w_in[i - 1] < a_threshold <= w_in[i]:
                 i_cross = i - 1
+                return
 
     if i_cross == -1:
         return


### PR DESCRIPTION
Changes to time_point_thresh_interpolated so that the first threshold crossing is returned and not the last, which is what we wanted/expected. It now matches time_point_thresh, the non-interpolated version, which is also in this file. 