### PR TITLE
Fixed precision bug in pole zero filters, added unit tests

### DIFF
--- a/src/dspeed/processors/pole_zero.py
+++ b/src/dspeed/processors/pole_zero.py
@@ -43,18 +43,23 @@ def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
         return
 
     const = np.exp(-1 / t_tau)
-    w_tmp = np.zeros(
-        len(w_in), dtype=np.float64
-    )  # truncating the output array at float32 causes instabilities in the filter
 
+    # Create a buffer of float64s, because performing the recursion at float32 causes instabilities in the filter due to truncation
+    w_tmp = np.zeros(2, dtype=np.float64)
+
+    # Initialize the arrays for recursion
+    w_out[0] = w_in[0]
     w_tmp[0] = w_in[0]
+
     for i in range(1, len(w_in), 1):
-        w_tmp[i] = w_tmp[i - 1] + w_in[i] - w_in[i - 1] * const
+        w_tmp[1] = w_tmp[0] + w_in[i] - w_in[i - 1] * const
+
+        w_out[i] = w_tmp[1]  # Put the higher precision buffer into the desired output
+        w_tmp[0] = w_tmp[1]  # Shuffle the buffer for the next iteration
 
     # Check the output
-    if np.isnan(w_tmp).any():
+    if np.isnan(w_out).any():
         raise DSPFatal("Pole-zero filter produced nans in output.")
-    w_out[:] = w_tmp[:]
 
 
 @guvectorize(
@@ -143,22 +148,29 @@ def double_pole_zero(
     transfer_num_1 = -1 * (a + b)
     transfer_num_2 = a * b
 
-    w_tmp = np.zeros(
-        len(w_in), dtype=np.float64
-    )  # truncating the output array at float32 causes instabilities in the filter
+    # Create a buffer of float64s, because performing the recursion at float32 causes instabilities in the filter due to truncation
+    w_tmp = np.zeros(3, dtype=np.float64)
+
+    # Initialize the arrays for recursion
     w_tmp[0] = w_in[0]
     w_tmp[1] = w_in[1]
-    w_tmp[2] = w_in[2]
+
+    w_out[0] = w_in[0]
+    w_out[1] = w_in[1]
 
     for i in range(2, len(w_in), 1):
-        w_tmp[i] = (
+        w_tmp[2] = (
             w_in[i]
             + transfer_num_1 * w_in[i - 1]
             + transfer_num_2 * w_in[i - 2]
-            - transfer_denom_1 * w_tmp[i - 1]
-            - transfer_denom_2 * w_tmp[i - 2]
+            - transfer_denom_1 * w_tmp[1]
+            - transfer_denom_2 * w_tmp[0]
         )
+
+        w_out[i] = w_tmp[2]  # Put the higher precision buffer into the desired output
+        # Shuffle the buffer for the next iteration
+        w_tmp[0] = w_tmp[1]
+        w_tmp[1] = w_tmp[2]
     # Check the output
-    if np.isnan(w_tmp).any():
-        raise DSPFatal("Pole-zero filter produced nans in output.")
-    w_out[:] = w_tmp[:]
+    if np.isnan(w_out).any():
+        raise DSPFatal("Double-pole-zero filter produced nans in output.")

--- a/src/dspeed/processors/pole_zero.py
+++ b/src/dspeed/processors/pole_zero.py
@@ -50,7 +50,6 @@ def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
 
 @guvectorize(
     [
-        "void(float32[:], float32, float32, float32, float32[:])",
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->(n)",

--- a/tests/processors/test_pole_zero.py
+++ b/tests/processors/test_pole_zero.py
@@ -11,9 +11,9 @@ def test_pole_zero(compare_numba_vs_python):
     """
 
     # Create a single exponential pulse to pole-zero correct
-    tau = 10
-    ts = np.arange(0, 100)
-    amplitude = 10
+    tau = 30000
+    ts = np.arange(0, 8192)
+    amplitude = 17500
     pulse_in = np.insert(amplitude * np.exp(-ts / tau), 0, np.zeros(20))
     pulse_in = np.array(pulse_in, dtype=np.float32)
 
@@ -27,9 +27,18 @@ def test_pole_zero(compare_numba_vs_python):
     step = np.full(len(ts), amplitude)
     w_out_expected = np.insert(step, 0, np.zeros(20))
 
+    # Check that it works at float32 precision
+    pulse_in.astype(np.float32)
+    tau = np.array([tau], dtype=np.float32)[0]
     assert np.allclose(
-        compare_numba_vs_python(pole_zero, pulse_in, tau),
-        w_out_expected,
+        compare_numba_vs_python(pole_zero, pulse_in, tau), w_out_expected, rtol=1e-07
+    )
+
+    # Check that it works at float64 precision
+    pulse_in.astype(np.float64)
+    tau = np.array([tau], dtype=np.float64)[0]
+    assert np.allclose(
+        compare_numba_vs_python(pole_zero, pulse_in, tau), w_out_expected, rtol=1e-07
     )
 
 
@@ -71,4 +80,16 @@ def test_double_pole_zero(compare_numba_vs_python):
     assert np.allclose(
         compare_numba_vs_python(double_pole_zero, pulse_in, tau1, tau2, frac),
         w_out_expected,
+        rtol=1e-7,
+    )
+
+    # Make sure that the processor also works for float32 precision
+    pulse_in.astype(np.float32)
+    tau1 = np.array([tau1], dtype=np.float32)[0]
+    tau2 = np.array([tau2], dtype=np.float32)[0]
+    frac = np.array([frac], dtype=np.float32)[0]
+    assert np.allclose(
+        compare_numba_vs_python(double_pole_zero, pulse_in, tau1, tau2, frac),
+        w_out_expected,
+        rtol=1e-7,
     )

--- a/tests/processors/test_pole_zero.py
+++ b/tests/processors/test_pole_zero.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest
+
+from dspeed.errors import DSPFatal
+from dspeed.processors import pole_zero, double_pole_zero
+
+
+def test_pole_zero(compare_numba_vs_python):
+    """
+    Test that the pole-zero filter can correct an RC decay pulse into a step function
+    """
+
+    # Create a single exponential pulse to pole-zero correct
+    tau = 10
+    ts = np.arange(0, 100)
+    amplitude = 10
+    pulse_in = np.insert(amplitude * np.exp(-ts / tau), 0, np.zeros(20))
+    pulse_in  = np.array(pulse_in, dtype=np.float32)
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in = np.ones(pulse_in.size)
+    w_in[4] = np.nan
+
+    assert np.all(
+        np.isnan(compare_numba_vs_python(pole_zero, w_in, tau))
+    )
+
+    # ensure that a valid input gives the expected output when comparing the pole-zero correction with the pole-zero processor
+    step = np.full(len(ts), amplitude)
+    w_out_expected = np.insert(step, 0, np.zeros(20))
+
+    assert np.allclose(
+        compare_numba_vs_python(pole_zero, pulse_in, tau),
+        w_out_expected,
+    )
+
+def test_double_pole_zero(compare_numba_vs_python):
+    """
+    Test that the double pole-zero filter can correct thw sum of two RC decays into a step function
+    """
+
+    # Create a double exponential pulse to double-pole-zero correct
+    wf_len = 8192
+    tp0 = 2
+    amplitude = 17500
+    tau1 = 1000
+    tau2 = 30000
+    frac = 0.98
+    ts = np.arange(0, wf_len-tp0)
+    ys = amplitude*(1-frac)*np.exp(-ts/tau1) + amplitude*frac*np.exp(-ts/tau2)
+    pulse_in = np.insert(ys, 0, np.zeros(tp0))
+    
+    # ensure the DSPFatal is raised if the waveform is too short
+    pulse_out = np.zeros(2, dtype=np.float64)
+    with pytest.raises(DSPFatal):
+        double_pole_zero(np.ones(2), tau1, tau2, frac, pulse_out)
+
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in = np.ones(pulse_in.size)
+    w_in[4] = np.nan
+
+    assert np.all(
+        np.isnan(compare_numba_vs_python(double_pole_zero, w_in, tau1, tau2, frac))
+    )
+
+    # ensure that a valid input gives the expected output when comparing the pole-zero correction with the pole-zero processor
+    step = np.full(len(ts), amplitude)
+    w_out_expected = np.insert(step, 0, np.zeros(tp0))
+
+    assert np.allclose(
+        compare_numba_vs_python(double_pole_zero, pulse_in, tau1, tau2, frac),
+        w_out_expected,
+    )

--- a/tests/processors/test_pole_zero.py
+++ b/tests/processors/test_pole_zero.py
@@ -35,7 +35,7 @@ def test_pole_zero(compare_numba_vs_python):
 
 def test_double_pole_zero(compare_numba_vs_python):
     """
-    Test that the double pole-zero filter can correct thw sum of two RC decays into a step function
+    Test that the double pole-zero filter can correct the sum of two RC decays into a step function
     """
 
     # Create a double exponential pulse to double-pole-zero correct

--- a/tests/processors/test_pole_zero.py
+++ b/tests/processors/test_pole_zero.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from dspeed.errors import DSPFatal
-from dspeed.processors import pole_zero, double_pole_zero
+from dspeed.processors import double_pole_zero, pole_zero
 
 
 def test_pole_zero(compare_numba_vs_python):
@@ -15,15 +15,13 @@ def test_pole_zero(compare_numba_vs_python):
     ts = np.arange(0, 100)
     amplitude = 10
     pulse_in = np.insert(amplitude * np.exp(-ts / tau), 0, np.zeros(20))
-    pulse_in  = np.array(pulse_in, dtype=np.float32)
+    pulse_in = np.array(pulse_in, dtype=np.float32)
 
     # ensure that if there is a nan in w_in, all nans are outputted
     w_in = np.ones(pulse_in.size)
     w_in[4] = np.nan
 
-    assert np.all(
-        np.isnan(compare_numba_vs_python(pole_zero, w_in, tau))
-    )
+    assert np.all(np.isnan(compare_numba_vs_python(pole_zero, w_in, tau)))
 
     # ensure that a valid input gives the expected output when comparing the pole-zero correction with the pole-zero processor
     step = np.full(len(ts), amplitude)
@@ -33,6 +31,7 @@ def test_pole_zero(compare_numba_vs_python):
         compare_numba_vs_python(pole_zero, pulse_in, tau),
         w_out_expected,
     )
+
 
 def test_double_pole_zero(compare_numba_vs_python):
     """
@@ -46,15 +45,16 @@ def test_double_pole_zero(compare_numba_vs_python):
     tau1 = 1000
     tau2 = 30000
     frac = 0.98
-    ts = np.arange(0, wf_len-tp0)
-    ys = amplitude*(1-frac)*np.exp(-ts/tau1) + amplitude*frac*np.exp(-ts/tau2)
+    ts = np.arange(0, wf_len - tp0)
+    ys = amplitude * (1 - frac) * np.exp(-ts / tau1) + amplitude * frac * np.exp(
+        -ts / tau2
+    )
     pulse_in = np.insert(ys, 0, np.zeros(tp0))
-    
+
     # ensure the DSPFatal is raised if the waveform is too short
     pulse_out = np.zeros(2, dtype=np.float64)
     with pytest.raises(DSPFatal):
         double_pole_zero(np.ones(2), tau1, tau2, frac, pulse_out)
-
 
     # ensure that if there is a nan in w_in, all nans are outputted
     w_in = np.ones(pulse_in.size)


### PR DESCRIPTION
Using float32 precision in the double pole zero filter runs into issues when waveform amplitudes are large. This can be seen in the following example piece of code: 
```py
from dspeed.processors import double_pole_zero
import numpy as np
# Create test waveform
wf_len = 8192
tp0 = 2
amplitude = 17500
tau1 = 1000
tau2 = 30000
frac = 0.98
ts = np.arange(0, wf_len-tp0)
ys = amplitude*(1-frac)*np.exp(-ts/tau1) + amplitude*frac*np.exp(-ts/tau2)
test_wf = np.insert(ys, 0, np.zeros(tp0))

# Save waveform as float32
test_wf_32 = np.array(test_wf, dtype=np.float32)
w_out_32 = np.zeros_like(test_wf_32)

# Save waveform as float64
test_wf_64 = np.array(test_wf, dtype=np.float64)
w_out_64 = np.zeros_like(test_wf_64)

# Run the double pole zero
double_pole_zero(test_wf_32, tau1 , tau2 , frac, w_out_32)
double_pole_zero(test_wf_64, tau1 , tau2 , frac, w_out_64)

w_out_64[-5:]
>>>  [17499.99998898, 17499.99998898, 17499.99998898, 17499.99998898,
        17499.99998897]
w_out_32[-5:]
>>> [17755.367, 17755.352, 17755.336, 17755.322, 17755.307]
```
The output for float64 is what I would expect (it is a step function that has the same amplitude as the input pulse of 17500). The output for float32 however is wildly different from a step function! The truncation of `np.exp(-1/tau2)` from float64 to float32 is a small difference, however, when this difference is multiplied by the large amplitude of the waveform the difference is no longer small and the filter becomes unstable. 

I recommend we carry out the computation using float64 precision and then downcast the output waveform before it is used in the rest of the processing chain as float32.