### PR TITLE
Added support for yaml files and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _____  _________________________________________________________________
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/legend-exp/dspeed?logo=github)
 ![License](https://img.shields.io/github/license/legend-exp/dspeed)
 [![Read the Docs](https://img.shields.io/readthedocs/dspeed?logo=readthedocs)](https://dspeed.readthedocs.io)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10684780.svg)](https://doi.org/10.5281/zenodo.10684780)
 
 # DSPeed
 DSPeed (pronounced dee-ess-speed) is a python-based package that performs bulk, high-performance digital signal processing (DSP) of time-series data such as digitized waveforms. This package is part of the [pygama](https://github.com/legend-exp/pygama) scientific computing suite.
@@ -26,3 +27,5 @@ DSPeed (pronounced dee-ess-speed) is a python-based package that performs bulk, 
 DSPeed enables the user to define an arbitrary chain of vectorized signal processing routines that can be applied in bulk to waveforms and other data provided using the [LH5-format](https://legend-exp.github.io/legend-data-format-specs). These routines can include [numpy ufuncs](https://numpy.org/doc/stable/reference/ufuncs.html), custom functions accelerated with [numba](https://numba.pydata.org/), or other arbitrary functions. DSPeed will carefully manage file I/O to optimize memory usage and performance. Processing chains are defined using highly portable JSON files that can be applied to data from multiple digitizers.
 
 See the [online documentation](https://dspeed.readthedocs.io/en/stable/) for more information!
+
+Please consider citing us using [https://doi.org/10.5281/zenodo.10684780](https://doi.org/10.5281/zenodo.10684780).

--- a/src/dspeed/build_dsp.py
+++ b/src/dspeed/build_dsp.py
@@ -4,7 +4,7 @@ on waveform data.
 """
 from __future__ import annotations
 
-import json
+from yaml import safe_load
 import logging
 import os
 
@@ -42,7 +42,7 @@ def build_dsp(
     f_dsp
         name of dsp-tier LH5 file to write to.
     dsp_config
-        :class:`dict` or name of JSON file containing
+        :class:`dict` or name of JSON or YAML file containing
         :class:`~.processing_chain.ProcessingChain` config. See
         :func:`~.processing_chain.build_processing_chain` for details.
     lh5_tables
@@ -51,7 +51,7 @@ def build_dsp(
         called raw that contains such a table. If ``None``, process
         all valid groups. Note that wildcards are accepted (e.g. "ch*").
     database
-        dictionary or name of JSON file containing a parameter database. See
+        dictionary or name of JSON or YAMLfile containing a parameter database. See
         :func:`~.processing_chain.build_processing_chain` for details.
     outputs
         list of parameter names to write to the output file. If not provided,
@@ -68,7 +68,7 @@ def build_dsp(
     block_width
         number of waveforms to process at a time.
     chan_config
-        contains JSON DSP configuration file names for every table in
+        contains JSON or YAML DSP configuration file names for every table in
         `lh5_tables`.
     """
 
@@ -131,14 +131,14 @@ def build_dsp(
     if len(lh5_tables) == 0:
         raise RuntimeError(f"could not find any valid LH5 table in {f_raw}")
 
-    # get the database parameters. For now, this will just be a dict in a json
+    # get the database parameters. For now, this will just be a dict in a
     # file, but eventually we will want to interface with the metadata repo
     if isinstance(database, str):
         with open(lh5.utils.expand_path(database)) as db_file:
-            database = json.load(db_file)
+            database = safe_load(db_file)
 
     if database and not isinstance(database, dict):
-        raise ValueError("input database is not a valid JSON file or dict")
+        raise ValueError("input database is not a valid JSON or YAML file or dict")
 
     if write_mode is None and os.path.isfile(f_dsp):
         raise FileExistsError(

--- a/src/dspeed/build_dsp.py
+++ b/src/dspeed/build_dsp.py
@@ -4,7 +4,6 @@ on waveform data.
 """
 from __future__ import annotations
 
-from yaml import safe_load
 import logging
 import os
 
@@ -12,6 +11,7 @@ import h5py
 import numpy as np
 from lgdo import lh5
 from tqdm.auto import tqdm
+from yaml import safe_load
 
 from .errors import DSPFatal
 from .processing_chain import build_processing_chain

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -2210,8 +2210,16 @@ def build_processing_chain(
                 log.debug(f"setting {new_var} = {fun_var}")
                 continue
 
-            module = importlib.import_module(recipe["module"])
-            func = getattr(module, recipe["function"])
+            if "module" in recipe:
+                module = importlib.import_module(recipe["module"])
+                func = getattr(module, recipe["function"])
+            else:
+                p = recipe["function"].rfind('.')
+                if p<0:
+                    raise ProcessingChainError(f"Must provide a module for function {recipe['function']}")
+                module = importlib.import_module(recipe["function"][:p])
+                func = getattr(module, recipe["function"][p+1:])
+
             args = recipe["args"]
             new_vars = [k for k in re.split(",| ", proc_par) if k != ""]
 

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import ast
 import importlib
 import itertools as it
-import json
+from yaml import safe_load, dump
 import logging
 import re
 from abc import ABCMeta, abstractmethod
@@ -1941,7 +1941,7 @@ def build_processing_chain(
 ) -> tuple[ProcessingChain, list[str], lgdo.Table]:
     """Produces a :class:`ProcessingChain` object and an LH5
     :class:`~lgdo.types.table.Table` for output parameters from an input LH5
-    :class:`~lgdo.types.table.Table` and a JSON recipe.
+    :class:`~lgdo.types.table.Table` and a JSON or YAML recipe.
 
     Parameters
     ----------
@@ -1950,7 +1950,7 @@ def build_processing_chain(
         should be read in prior to calling this!
 
     dsp_config
-        A dictionary or JSON filename containing the recipes for computing DSP
+        A dictionary or YAML/JSON filename containing the recipes for computing DSP
         parameter from raw parameters. The format is as follows:
 
         .. code-block:: json
@@ -2024,14 +2024,14 @@ def build_processing_chain(
 
     if isinstance(dsp_config, str):
         with open(lh5.utils.expand_path(dsp_config)) as f:
-            dsp_config = json.load(f)
+            dsp_config = safe_load(f)
     elif dsp_config is None:
         dsp_config = {"outputs": [], "processors": {}}
     elif isinstance(dsp_config, dict):
         # We don't want to modify the input!
         dsp_config = deepcopy(dsp_config)
     else:
-        raise ValueError("dsp_config must be a dict, json file, or None")
+        raise ValueError("dsp_config must be a dict, json/yaml file, or None")
 
     if outputs is None:
         outputs = dsp_config["outputs"]
@@ -2317,7 +2317,7 @@ def build_processing_chain(
         except Exception as e:
             raise ProcessingChainError(
                 "Exception raised while attempting to add processor:\n"
-                + json.dumps(recipe, indent=2)
+                + dump(recipe)
             ) from e
 
     # build the output buffers

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -977,7 +977,7 @@ class ProcessingChain:
                 for kwarg in node.keywords
             }
             if func is not None:
-                return func(*args, **kwargs)
+                return func(*args, **kwargs) if not dry_run else None
             elif self._validate_name(node.func.id):
                 var_name = node.func.id
                 var_name_list.append(var_name)
@@ -2226,6 +2226,7 @@ def build_processing_chain(
 
             # get this list of kwargs
             kwargs = recipe.get("kwargs", {})  # might also need db lookup here
+            kwargs.update({key:recipe[key] for key in ["signature", "types", "coord_grid"] if key in recipe})
 
             # if init_args are defined, parse any strings and then call func
             # as a factory/constructor function

--- a/tests/configs/icpc-dsp-config.yaml
+++ b/tests/configs/icpc-dsp-config.yaml
@@ -1,0 +1,262 @@
+outputs:
+ -tp_min
+ -tp_max
+ -wf_min
+ -wf_max
+ -bl_mean
+ -bl_std
+ -bl_slope
+ -bl_intercept
+ -pz_slope
+ -pz_std
+ -pz_mean
+ -trapTmax
+ -tp_0_est
+ -tp_0_atrap
+ -tp_10
+ -tp_20
+ -tp_50
+ -tp_80
+ -tp_90
+ -tp_99
+ -tp_100
+ -tp_01
+ -tp_95
+ -A_max
+ -QDrift
+ -dt_eff
+ -tp_aoe_max
+ -tp_aoe_samp
+ -trapEmax
+ -trapEftp
+ -cuspEmax
+ -zacEmax
+ -zacEftp
+ -cuspEftp
+processors:
+  tp_min, tp_max, wf_min, wf_max:
+     function: dspeed.processors.min_max
+     args: [waveform, tp_min, tp_max, wf_min, wf_max]
+     unit: [ns, ns, ADC, ADC]
+  wf_blsub:
+    function: dspeed.processors.bl_subtract
+    args: [waveform, baseline, wf_blsub]
+    unit: ADC
+  bl_mean, bl_std, bl_slope, bl_intercept:
+    function: dspeed.processors.linear_slope_fit
+    args: ["wf_blsub[0:750]", bl_mean, bl_std, bl_slope, bl_intercept]
+    unit: [ADC, ADC, ADC, ADC]
+  wf_pz:
+    function: dspeed.processors.pole_zero
+    args: [wf_blsub, db.pz.tau, wf_pz]
+    unit: ADC
+    defaults:
+      db.pz.tau: 27460.5
+  pz_mean , pz_std, pz_slope, pz_intercept:
+    function: dspeed.processors.linear_slope_fit
+    args: ["wf_pz[1500:]", pz_mean, pz_std, pz_slope, pz_intercept]
+    unit: [ADC, ADC, ADC, ADC]
+  t0_kernel:
+    function: dspeed.processors.t0_filter
+    args: [128*ns, 2*us, "t0_kernel(round(128*ns+2*us, wf_pz.period), 'f')"]
+    coord_grid: wf_pz
+    unit: ADC
+  wf_t0_filter:
+    function: dspeed.processors.convolve_wf
+    args: [wf_pz, t0_kernel, "'s'", "wf_t0_filter(len(wf_pz), 'f', grid=wf_pz.grid)"]
+    unit: ADC
+  wf_atrap:
+    function: dspeed.processors.asym_trap_filter
+    args: [wf_pz, 128*ns, 4, 2*us, wf_atrap]
+    unit: ADC
+  conv_tmin ,tp_start, conv_min, conv_max:
+    function: dspeed.processors.min_max
+    args: [wf_t0_filter, conv_tmin, tp_start, conv_min, conv_max]
+    unit: [ns, ns, ADC, ADC]
+  tp_0_atrap:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_atrap, bl_std, tp_start, 0, tp_0_atrap]
+    unit: ns
+  tp_0_est:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_t0_filter, bl_std, tp_start, 0, tp_0_est(unit=ns)]
+    unit: ns
+  wf_trap:
+    function: dspeed.processors.trap_norm
+    args: [wf_pz, db.ttrap.rise, db.ttrap.flat, wf_trap]
+    unit: ADC
+    defaults:
+      db.ttrap.rise: 10*us
+      db.ttrap.flat: 3.008*us
+  trapTmax:
+    function: numpy.amax
+    args: [wf_trap, 1, trapTmax]
+    signature: (n),()->()
+    types: [fi->f]
+    unit: ADC
+  wf_etrap:
+    function: dspeed.processors.trap_norm
+    args: [wf_pz, db.etrap.rise, db.etrap.flat, wf_etrap]
+    unit: ADC
+    defaults:
+      db.etrap.rise: 10*us
+      db.etrap.flat: 3.008*us
+  trapEmax:
+    function: numpy.amax
+    args: [wf_etrap, 1, trapEmax]
+    signature: (n),()->()
+    types: [fi->f]
+    unit: ADC
+  trapEftp:
+    function: dspeed.processors.fixed_time_pickoff
+    args:
+      - wf_etrap
+      - round(tp_0_est+db.etrap.rise+db.etrap.flat*db.etrap.sample, wf_etrap.grid)
+      - "'l'"
+      - trapEftp
+    unit: ADC
+    defaults:
+      db.etrap.rise: 10*us
+      db.etrap.flat: 3*us
+      db.etrap.sample: 0.8
+  cusp_kernel:
+    function: dspeed.processors.cusp_filter
+    args:
+      - db.cusp.sigma
+      - round(db.cusp.flat, wf_blsub.period)
+      - db.pz.tau
+      - cusp_kernel(len(wf_blsub)-round(33.6*us - 4.8*us, wf_blsub.period), 'f')
+    defaults:
+      db.cusp.sigma: 20*us
+      db.cusp.flat: 3*us
+      db.pz.tau: 450*us
+    coord_grid: wf_blsub
+    unit: ADC
+  wf_cusp:
+    function: dspeed.processors.fft_convolve_wf
+    args:
+      - wf_blsub[:len(wf_blsub)-round(33.6*us, wf_blsub.period)]
+      - cusp_kernel
+      - "'v'"
+      - wf_cusp(round(4.8*us, wf_blsub.period) + 1, 'f')
+    unit: ADC
+  cuspEmax:
+    function: numpy.amax
+    args: [wf_cusp, 1, cuspEmax]
+    signature: (n),()->()
+    types: [fi->f]
+    unit: ADC
+  cuspEftp:
+    function: dspeed.processors.fixed_time_pickoff
+    args: [wf_cusp, db.cusp.sample, "'i'", cuspEftp]
+    unit: ADC
+    defaults:
+      db.cusp.sample: 50
+  zac_kernel:
+    function: dspeed.processors.zac_filter
+    args:
+      - db.zac.sigma/wf_blsub.period
+      - round(db.zac.flat/wf_blsub.period)
+      - db.pz.tau/wf_blsub.period
+      - zac_kernel(round(len(wf_blsub)-(33.6*us/wf_blsub.period)-(4.8*us/wf_blsub.period)), 'f')
+    defaults:
+      db.zac.sigma: 20*us
+      db.zac.flat: 3*us
+      db.pz.tau: 450*us
+    unit: ADC
+  wf_zac:
+    function: dspeed.processors.fft_convolve_wf
+    args:
+      - wf_blsub[:round(len(wf_blsub)-(33.6*us/wf_blsub.period))]
+      - zac_kernel
+      - "'v'"
+      - wf_zac(round((4.8*us/wf_blsub.period)+1), 'f')
+    unit: ADC
+  zacEmax:
+    function: numpy.amax
+    args: [wf_zac, 1, zacEmax]
+    signature: (n),()->()
+    types: [fi->f]
+    unit: ADC
+  zacEftp:
+    function: dspeed.processors.fixed_time_pickoff
+    args: [wf_zac, db.zac.sample, "'i'", zacEftp]
+    defaults:
+      db.zac.sample: 50
+    unit: ADC
+  tp_100:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax, tp_0_est, 1, tp_100]
+    unit: ns
+  tp_99:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, 0.99*trapTmax, tp_0_est, 1, tp_99]
+    unit: ns
+  tp_95:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.95, tp_99, 0, tp_95]
+    unit: ns
+  tp_90:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.9, tp_95, 0, tp_90]
+    unit: ns
+  tp_80:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.8, tp_90, 0, tp_80]
+    unit: ns
+  tp_50:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.5, tp_80, 0, tp_50]
+    unit: ns
+  tp_20:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.2, tp_50, 0, tp_20]
+    unit: ns
+  tp_10:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.1, tp_20, 0, tp_10]
+    unit: ns
+  tp_01:
+    function: dspeed.processors.time_point_thresh
+    args: [wf_pz, trapTmax*0.01, tp_10, 0, tp_01]
+    unit: ns
+  wf_trap2:
+    function: dspeed.processors.trap_norm
+    args: [wf_pz, 4*us, 96*ns, wf_trap2]
+    unit: ADC
+  trapQftp:
+    function: dspeed.processors.fixed_time_pickoff
+    args: [wf_trap2, tp_0_est + 8.096*us, "'l'", trapQftp]
+    unit: ADC
+  QDrift:
+    function: numpy.multiply
+    args: [trapQftp, (4*us)/waveform.period, QDrift]
+    unit: ADC
+  dt_eff:
+    function: numpy.divide
+    args: [QDrift, trapTmax, dt_eff]
+    unit: ns
+  wf_le:
+    function: dspeed.processors.windower
+    args: [wf_pz, tp_0_est, "wf_le(301, 'f')"]
+    unit: ADC
+  curr:
+    function: dspeed.processors.avg_current
+    args: [wf_le, 1, "curr(len(wf_le)-1, 'f')"]
+    unit: ADC/sample
+  curr_up:
+    function: dspeed.processors.upsampler
+    args: [curr, 16, "curr_up(4784, 'f')"]
+    unit: ADC/sample
+  curr_av:
+    function: dspeed.processors.moving_window_multi
+    args: [curr_up, 48, 3, 0, curr_av]
+    unit: ADC/sample
+  aoe_t_min, tp_aoe_max, A_min, A_max:
+    function: dspeed.processors.min_max
+    args: [curr_av, aoe_t_min, tp_aoe_max, A_min, A_max]
+    unit: [ns, ns, ADC/sample, ADC/sample]
+  tp_aoe_samp:
+    function: dspeed.processors.add
+    args: [tp_0_est, tp_aoe_max/16, tp_aoe_samp]
+    unit: ns

--- a/tests/test_build_dsp.py
+++ b/tests/test_build_dsp.py
@@ -10,12 +10,23 @@ from dspeed import build_dsp
 config_dir = Path(__file__).parent / "configs"
 
 
-def test_build_dsp_basics(lgnd_test_data, tmptestdir):
+def test_build_dsp_json(lgnd_test_data, tmptestdir):
     out_name = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds_dsp.lh5"
     build_dsp(
         lgnd_test_data.get_path("lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5"),
         out_name,
         dsp_config=f"{config_dir}/icpc-dsp-config.json",
+        database={"pz": {"tau": 27460.5}},
+        write_mode="r",
+    )
+    assert os.path.exists(out_name)
+
+def test_build_dsp_yaml(lgnd_test_data, tmptestdir):
+    out_name = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds_dsp.lh5"
+    build_dsp(
+        lgnd_test_data.get_path("lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5"),
+        out_name,
+        dsp_config=f"{config_dir}/icpc-dsp-config.yaml",
         database={"pz": {"tau": 27460.5}},
         write_mode="r",
     )

--- a/tests/test_build_dsp.py
+++ b/tests/test_build_dsp.py
@@ -21,6 +21,7 @@ def test_build_dsp_json(lgnd_test_data, tmptestdir):
     )
     assert os.path.exists(out_name)
 
+
 def test_build_dsp_yaml(lgnd_test_data, tmptestdir):
     out_name = f"{tmptestdir}/LDQTA_r117_20200110T105115Z_cal_geds_dsp.lh5"
     build_dsp(

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -157,7 +157,7 @@ def test_processor_variable_array_output(spms_raw_tbl):
 # a windowed wf and a down-sampled waveform; they should be the same
 def test_proc_chain_coordinate_grid(spms_raw_tbl):
     dsp_config = {
-        "outputs": ["a_window", "a_downsample"],
+        "outputs": ["a_window", "a_downsample", "tp", "tp_window", "tp_downsample"],
         "processors": {
             "a_window": {
                 "function": "fixed_time_pickoff",
@@ -181,12 +181,33 @@ def test_proc_chain_coordinate_grid(spms_raw_tbl):
                 ],
                 "unit": ["ADC"],
             },
+            "tp": {
+                "function": "time_point_thresh",
+                "module": "dspeed.processors",
+                "args": ["waveform", "a_window", "52.48*us+waveform.offset", 0, "tp"],
+                "unit": "ns"
+            },
+            "tp_window": {
+                "function": "time_point_thresh",
+                "module": "dspeed.processors",
+                "args": ["waveform[2625:4025]", "a_window", "52.48*us+waveform.offset", 0, "tp_window"],
+                "unit": "ns"
+            },
+            "tp_downsample": {
+                "function": "time_point_thresh",
+                "module": "dspeed.processors",
+                "args": ["waveform[0:8000:8]", "a_window", "52.48*us+waveform.offset", 0, "tp_downsample"],
+                "unit": "ns"
+            },
         },
     }
 
     proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
     proc_chain.execute(0, 1)
+    print(lh5_out["tp"][0], lh5_out["tp_window"][0], lh5_out["tp_downsample"][0])
     assert lh5_out["a_window"][0] == lh5_out["a_downsample"][0]
+    assert lh5_out["tp_window"][0] == lh5_out["tp"][0]
+    assert -128 < lh5_out["tp_downsample"][0] - lh5_out["tp"][0] < 128
 
 
 def test_proc_chain_round(spms_raw_tbl):

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -185,19 +185,31 @@ def test_proc_chain_coordinate_grid(spms_raw_tbl):
                 "function": "time_point_thresh",
                 "module": "dspeed.processors",
                 "args": ["waveform", "a_window", "52.48*us+waveform.offset", 0, "tp"],
-                "unit": "ns"
+                "unit": "ns",
             },
             "tp_window": {
                 "function": "time_point_thresh",
                 "module": "dspeed.processors",
-                "args": ["waveform[2625:4025]", "a_window", "52.48*us+waveform.offset", 0, "tp_window"],
-                "unit": "ns"
+                "args": [
+                    "waveform[2625:4025]",
+                    "a_window",
+                    "52.48*us+waveform.offset",
+                    0,
+                    "tp_window",
+                ],
+                "unit": "ns",
             },
             "tp_downsample": {
                 "function": "time_point_thresh",
                 "module": "dspeed.processors",
-                "args": ["waveform[0:8000:8]", "a_window", "52.48*us+waveform.offset", 0, "tp_downsample"],
-                "unit": "ns"
+                "args": [
+                    "waveform[0:8000:8]",
+                    "a_window",
+                    "52.48*us+waveform.offset",
+                    0,
+                    "tp_downsample",
+                ],
+                "unit": "ns",
             },
         },
     }

--- a/tests/test_processing_chain.py
+++ b/tests/test_processing_chain.py
@@ -216,7 +216,6 @@ def test_proc_chain_coordinate_grid(spms_raw_tbl):
 
     proc_chain, _, lh5_out = build_processing_chain(spms_raw_tbl, dsp_config)
     proc_chain.execute(0, 1)
-    print(lh5_out["tp"][0], lh5_out["tp_window"][0], lh5_out["tp_downsample"][0])
     assert lh5_out["a_window"][0] == lh5_out["a_downsample"][0]
     assert lh5_out["tp_window"][0] == lh5_out["tp"][0]
     assert -128 < lh5_out["tp_downsample"][0] - lh5_out["tp"][0] < 128


### PR DESCRIPTION
- Added support for yaml files using "safe_load"
- Made it possible to set coord_grid directly rather than setting period and offset separately
- The signature and types in kwargs can now be included either through kwargs or as their own json/yaml entries (I may deprecate kwargs at some point)
- module entry is now unnecessary; instead you can prepend the module to the function name (i.e. `dspeed.processors.trap`)
- Fixed a bug that was causing unit conversions to mess up for time coordinates when reading them as outputs
- Added tests