### PR TITLE
Improved handling of coordinate variables

### DIFF
--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -43,9 +43,11 @@ ast_ops_dict = {
     ast.USub: (np.negative, "-{}"),
 }
 
+
 # helper function to tell if an object is found in the unit registry
 def is_in_pint(unit):
     return isinstance(unit, (Unit, Quantity)) or (unit and unit in ureg)
+
 
 @dataclass
 class CoordinateGrid:
@@ -496,12 +498,7 @@ class ProcessingChain:
 
         val = np.array(val, dtype=dtype)
 
-        param.update_auto(
-            shape=val.shape,
-            dtype=val.dtype,
-            unit=unit,
-            is_coord=False
-        )
+        param.update_auto(shape=val.shape, dtype=val.dtype, unit=unit, is_coord=False)
         np.copyto(param.get_buffer(), val, casting="unsafe")
         log.debug(f"set constant: {param.description()} = {val}")
         return param
@@ -830,7 +827,7 @@ class ProcessingChain:
             if isinstance(lhs, ProcChainVar) and isinstance(rhs, ProcChainVar):
                 if is_in_pint(lhs.unit) and is_in_pint(rhs.unit):
                     unit = op(Quantity(lhs.unit), Quantity(rhs.unit)).u
-                    if unit==ureg.dimensionless:
+                    if unit == ureg.dimensionless:
                         unit = None
                 elif lhs.unit is not None and rhs.unit is not None:
                     unit = op_form.format(str(lhs.unit), str(rhs.unit))
@@ -843,9 +840,11 @@ class ProcessingChain:
                 out = ProcChainVar(
                     self,
                     name,
-                    grid = None if lhs.is_coord and rhs.is_coord else auto,
-                    is_coord = False if lhs.is_coord is True and rhs.is_coord is True else auto,
-                    unit = unit
+                    grid=None if lhs.is_coord and rhs.is_coord else auto,
+                    is_coord=False
+                    if lhs.is_coord is True and rhs.is_coord is True
+                    else auto,
+                    unit=unit,
                 )
             elif isinstance(lhs, ProcChainVar):
                 out = ProcChainVar(
@@ -897,7 +896,7 @@ class ProcessingChain:
             val = self._parse_expr(node.value, expr, dry_run, var_name_list)
             if val is None:
                 return None
-            if not isinstance(val, ProcChainVar) or not len(val.shape)>0:
+            if not isinstance(val, ProcChainVar) or not len(val.shape) > 0:
                 raise ProcessingChainError("Cannot apply subscript to", node.value)
 
             def get_index(slice_value):
@@ -1300,8 +1299,12 @@ class ProcessorManager:
                 d.strip() for d in dims.split(",") if d
             ]
             arr_dims = list(param.shape)
-            if isinstance(param, ProcChainVar) and param.grid is not auto and not param.is_coord:
-                arr_grid =  param.grid
+            if (
+                isinstance(param, ProcChainVar)
+                and param.grid is not auto
+                and not param.is_coord
+            ):
+                arr_grid = param.grid
             else:
                 arr_grid = None
             if not grid:

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -902,7 +902,7 @@ class ProcessingChain:
                 index = get_index(node.slice)
                 out_buf = val.buffer[..., index]
                 out_name = f"{str(val)}[{index}]"
-                out_grid = None
+                out_grid = val.grid if val.is_coord else None
 
             elif isinstance(node.slice, ast.Slice):
                 sl = slice(

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -1803,8 +1803,8 @@ class LGDOVectorOfVectorsIOManager(IOManager):
                 f"{var.vector_len} must be an integer to act as a vector len"
             )
 
-        unit = io_array.attrs.get("units", None)
-        var.update_auto(dtype=io_array.dtype, shape=io_array.nda.shape[1:], unit=unit)
+        unit = io_vov.attrs.get("units", None)
+        var.update_auto(dtype=io_vov.dtype, shape=10, unit=unit)
 
         if isinstance(var.unit, (CoordinateGrid, Quantity, Unit)):
             if isinstance(var.unit, CoordinateGrid):
@@ -1826,7 +1826,7 @@ class LGDOVectorOfVectorsIOManager(IOManager):
         elif isinstance(var.unit, str) and unit is None:
             unit = var.unit
 
-        if "units" not in io_array.attrs and unit is not None:
+        if "units" not in io_vov.attrs and unit is not None:
             io_vov.attrs["units"] = str(unit)
 
         self.io_vov = io_vov

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -880,7 +880,7 @@ class ProcessingChain:
             val = self._parse_expr(node.value, expr, dry_run, var_name_list)
             if val is None:
                 return None
-            if not isinstance(val, ProcChainVar):
+            if not isinstance(val, ProcChainVar) or not len(val.shape)>0:
                 raise ProcessingChainError("Cannot apply subscript to", node.value)
 
             def get_index(slice_value):
@@ -898,10 +898,10 @@ class ProcessingChain:
                     return round_ret
                 return int(ret)
 
-            if isinstance(node.slice, ast.Index):
-                index = get_index(node.slice.value)
-                out_buf = val[..., index]
-                out_name = (f"{str(val)}[{index}]",)
+            if isinstance(node.slice, ast.Constant):
+                index = get_index(node.slice)
+                out_buf = val.buffer[..., index]
+                out_name = f"{str(val)}[{index}]"
                 out_grid = None
 
             elif isinstance(node.slice, ast.Slice):

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -501,6 +501,7 @@ class ProcessingChain:
             shape=val.shape,
             dtype=val.dtype,
             unit=unit,
+            is_coord=False
         )
         np.copyto(param.get_buffer(), val, casting="unsafe")
         log.debug(f"set constant: {param.description()} = {val}")

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -828,8 +828,25 @@ class ProcessingChain:
 
             name = "(" + op_form.format(str(lhs), str(rhs)) + ")"
             if isinstance(lhs, ProcChainVar) and isinstance(rhs, ProcChainVar):
-                # TODO: handle units/coords; for now make them match lhs
-                out = ProcChainVar(self, name, is_coord=lhs.is_coord)
+                if is_in_pint(lhs.unit) and is_in_pint(rhs.unit):
+                    unit = op(Quantity(lhs.unit), Quantity(rhs.unit)).u
+                    if unit==ureg.dimensionless:
+                        unit = None
+                elif lhs.unit is not None and rhs.unit is not None:
+                    unit = op_form.format(str(lhs.unit), str(rhs.unit))
+                elif lhs.unit is not None:
+                    unit = lhs.unit
+                else:
+                    unit = rhs.unit
+                # If both vars are coordinates, this is probably not a coord.
+                # If one var is a coord, this is probably a coord
+                out = ProcChainVar(
+                    self,
+                    name,
+                    grid = None if lhs.is_coord and rhs.is_coord else auto,
+                    is_coord = False if lhs.is_coord is True and rhs.is_coord is True else auto,
+                    unit = unit
+                )
             elif isinstance(lhs, ProcChainVar):
                 out = ProcChainVar(
                     self,

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -488,8 +488,8 @@ class ProcessingChain:
         """
 
         param = self.get_variable(varname)
-        assert param.is_constant or param._buffer is None
-        param.is_constant = True
+        assert param.is_const or param._buffer is None
+        param.is_const = True
 
         if isinstance(val, Quantity):
             unit = val.unit

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -422,10 +422,10 @@ class WaveformBrowser:
             elif isinstance(
                 data, (lgdo.Array, lgdo.ArrayOfEqualSizedArrays, lgdo.VectorOfVectors)
             ):
-                if isinstance(data, lgdo.Array):
-                    vals = [data.nda[i_tb]]
+                if isinstance(data, (lgdo.ArrayOfEqualSizedArrays, lgdo.VectorOfVectors)):
+                    vals = list(data.nda[i_tb])
                 else:
-                    vals = data[i_tb]
+                    vals = [data.nda[i_tb]]
 
                 unit = data.attrs.get("units", None)
                 if unit and unit in ureg and ureg.is_compatible_with(unit, self.x_unit):

--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -422,7 +422,9 @@ class WaveformBrowser:
             elif isinstance(
                 data, (lgdo.Array, lgdo.ArrayOfEqualSizedArrays, lgdo.VectorOfVectors)
             ):
-                if isinstance(data, (lgdo.ArrayOfEqualSizedArrays, lgdo.VectorOfVectors)):
+                if isinstance(
+                    data, (lgdo.ArrayOfEqualSizedArrays, lgdo.VectorOfVectors)
+                ):
                     vals = list(data.nda[i_tb])
                 else:
                     vals = [data.nda[i_tb]]


### PR DESCRIPTION
- Handle binary operators on coordinate variables correctly. Before, result of binary operator just inherited the first variables coordinate grid and status as a coordinate variable. Now, it:
  - If both variables are coordinates, treats the result as not a coordinate. This is because the most likely use case for this is for differences between time points, and these should not be coordinates
  - If one variable is a coordinate, inherit the values from that variable. This is because the most likely result for this is applying an offset to a coordinate (e.g. 5*us from tp_0)
  - If neither variable is a coordinate, result is not a coordinate
  - If these cases are not suitable, user will have to specify it
- Fixed failure to convert units correctly for coordinates when writing output buffers for VectorOfVectors and ArrayOfEqualSizeArrays
- Made single-value subscripts work as expected
- Fixed error raised when adding constant values
- Fixed bug that prevented all values in VoV and AoESA to be drawn by waveform browser
- Constant values are by default not treated as coordinates
- Other small bug fixes and code cleanups