### PR TITLE
Added RC-CR^2 filter

### DIFF
--- a/src/dspeed/processors/__init__.py
+++ b/src/dspeed/processors/__init__.py
@@ -87,12 +87,14 @@ from .peak_snr_threshold import peak_snr_threshold
 from .pole_zero import double_pole_zero, pole_zero
 from .presum import presum
 from .pulse_injector import inject_exp_pulse, inject_sig_pulse
+from .rc_cr2 import rc_cr2
 from .round_to_nearest import round_to_nearest
 from .saturation import saturation
 from .soft_pileup_corr import soft_pileup_corr, soft_pileup_corr_bl
 from .svm import svm_predict
 from .time_over_threshold import time_over_threshold
 from .time_point_thresh import (
+    bi_level_zero_crossing_time_points,
     interpolated_time_point_thresh,
     multi_time_point_thresh,
     time_point_thresh,
@@ -164,4 +166,6 @@ __all__ = [
     "wf_alignment",
     "round_to_nearest",
     "transfer_function_convolver",
+    "rc_cr2",
+    "bi_level_zero_crossing_time_points",
 ]

--- a/src/dspeed/processors/rc_cr2.py
+++ b/src/dspeed/processors/rc_cr2.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+from numba import guvectorize
+
+from ..errors import DSPFatal
+from ..utils import numba_defaults_kwargs as nb_kwargs
+
+
+@guvectorize(
+    ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
+    "(n),()->(n)",
+    **nb_kwargs,
+)
+def rc_cr2(w_in: np.array, t_tau: float, w_out: np.array) -> None:
+    """
+    Apply a RC-CR^2 filter with the provided time
+    constant to the waveform. Useful for determining pileup
+    and trigger times. The filter was computed using a matched z-transform
+    to keep the poles/zeroes of the analog transfer function in the same location.
+
+    Parameters
+    ----------
+    w_in
+        the input waveform.
+    t_tau
+        the time constant of the integration and differentiaion
+    w_out
+        the RC-CR^2 filtered waveform.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "wf_RC_CR2": {
+            "function": "rc_cr2",
+            "module": "dspeed.processors",
+            "args": ["wf_bl", "300*ns", "wf_RC_CR2"],
+            "unit": "ADC"
+        }
+    """
+    w_out[:] = np.nan
+
+    if np.isnan(w_in).any() or np.isnan(t_tau):
+        return
+
+    if len(w_in) <= 3:
+        raise DSPFatal(
+            "The length of the waveform must be larger than 3 for the filter to work safely"
+        )
+
+    w_out[0] = w_in[0]
+    w_out[1] = w_in[1]
+    w_out[2] = w_in[2]
+
+    # Make a temporary buffer at higher precision so that the recursive filter doesn't compound any float truncations
+    w_tmp = np.zeros(4, dtype=np.float64)
+    w_tmp[0] = w_in[0]
+    w_tmp[1] = w_in[1]
+    w_tmp[2] = w_in[2]
+
+    a = np.exp(-1 / t_tau)
+
+    denom_1 = 1
+    denom_2 = -3 * a
+    denom_3 = 3 * a**2
+    denom_4 = -(a**3)
+
+    num_1 = 1
+    num_2 = -2
+    num_3 = 1
+
+    for i in range(3, len(w_in)):
+        w_tmp[3] = (
+            -denom_2 * w_tmp[2]
+            - denom_3 * w_tmp[1]
+            - denom_4 * w_tmp[0]
+            + num_1 * w_in[i]
+            + num_2 * w_in[i - 1]
+            + num_3 * w_in[i - 2]
+        ) / denom_1
+        w_out[i] = w_tmp[3]  # Put the higher precision buffer into the desired output
+        # shuffle the buffers
+        w_tmp[0] = w_tmp[1]
+        w_tmp[1] = w_tmp[2]
+        w_tmp[2] = w_tmp[3]
+
+    # Check the output
+    if np.isnan(w_out).any():
+        raise DSPFatal("RC-CR^2 filter produced nans in output.")

--- a/src/dspeed/processors/time_point_thresh.py
+++ b/src/dspeed/processors/time_point_thresh.py
@@ -367,3 +367,114 @@ def multi_time_point_thresh(
                 if i_tp < 0:
                     break
                 idx = sorted_idx[i_tp]
+
+
+@guvectorize(
+    [
+        "void(float32[:], float32, float32, float32, float32, float32[:])",
+        "void(float64[:], float64, float64, float64, float64, float64[:])",
+    ],
+    "(n),(),(),(),(),(m)",
+    **nb_kwargs,
+)
+def bi_level_zero_crossing_time_points(
+    w_in: np.ndarray,
+    a_pos_threshold_in: float,
+    a_neg_threshold_in: float,
+    gate_time: int,
+    t_start_in: int,
+    t_trig_times_out: np.array,
+) -> None:
+    """
+    Find the indices where a waveform value crosses 0 after crossing the threshold and reaching the next threshold within some gate time.
+    Works on positive and negative polarity waveforms.
+    Useful for finding pileup events with the RC-CR^2 filter.
+
+    Parameters
+    ----------
+    w_in
+        the input waveform.
+    a_pos_threshold_in
+        the positive threshold value.
+    a_neg_threshold_in
+        the negative threshold value.
+    gate_time
+        The number of samples that the next threshold crossing has to be within in order to count a 0 crossing
+    t_start_in
+        the starting index.
+    t_trig_times_out
+        the indices where the waveform value has crossed the threshold and returned to 0.
+        Arrays of fixed length (padded with :any:`numpy.nan`) that hold the
+        indices of the identified trigger times.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "trig_times_out": {
+            "function": "bi_level_zero_crossing_time_points",
+            "module": "dspeed.processors",
+            "args": ["wf_rc_cr2", "5", "-10", 1000, 0, "trig_times_out(20)"],
+            "unit": "ns"
+        }
+    """
+    # prepare output
+    t_trig_times_out[:] = np.nan
+
+    # Check everything is ok
+    if (
+        np.isnan(w_in).any()
+        or np.isnan(a_pos_threshold_in)
+        or np.isnan(a_neg_threshold_in)
+        or np.isnan(t_start_in)
+    ):
+        return
+
+    if np.floor(t_start_in) != t_start_in:
+        raise DSPFatal("The starting index must be an integer")
+
+    if int(t_start_in) < 0 or int(t_start_in) >= len(w_in):
+        raise DSPFatal("The starting index is out of range")
+
+    gate_time = int(gate_time)  # make sure this is an integer!
+    # Perform the processing
+    is_above_thresh = False
+    is_below_thresh = False
+    crossed_zero = False
+    trig_array_idx = 0
+    for i in range(int(t_start_in), len(w_in) - 1, 1):
+        if is_below_thresh and (w_in[i] <= 0 < w_in[i + 1]):
+            crossed_zero = True
+            neg_trig_time_candidate = i
+
+        # Either we go above threshold
+        if w_in[i] <= a_pos_threshold_in < w_in[i + 1]:
+            if crossed_zero and is_below_thresh:
+                if i - is_below_thresh < gate_time:
+                    t_trig_times_out[trig_array_idx] = neg_trig_time_candidate
+                    trig_array_idx += 1
+                else:
+                    is_above_thresh = i
+
+                is_below_thresh = False
+                crossed_zero = False
+            else:
+                is_above_thresh = i
+
+        if is_above_thresh and (w_in[i] >= 0 > w_in[i + 1]):
+            crossed_zero = True
+            pos_trig_time_candidate = i
+
+        # Or we go below threshold
+        if w_in[i] >= a_neg_threshold_in > w_in[i + 1]:
+            if crossed_zero and is_above_thresh:
+                if i - is_above_thresh < gate_time:
+                    t_trig_times_out[trig_array_idx] = pos_trig_time_candidate
+                    trig_array_idx += 1
+                else:
+                    is_below_thresh = i
+                is_above_thresh = False
+                crossed_zero = False
+            else:
+                is_below_thresh = i

--- a/tests/processors/test_rc_cr2.py
+++ b/tests/processors/test_rc_cr2.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+from dspeed.errors import DSPFatal
+from dspeed.processors import rc_cr2
+
+
+def test_rc_cr2(compare_numba_vs_python):
+    # Create a single exponential pulse to RC-CR^2 filter
+    zeta = 30000
+    ts = np.arange(0, 8192 // 2)
+    amplitude = 17500
+    pulse_in = np.insert(amplitude * np.exp(-ts / zeta), 0, np.zeros(8192 // 2))
+    pulse_in = np.array(pulse_in, dtype=np.float32)
+    tau = 500
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in = np.ones(pulse_in.size)
+    w_in[4] = np.nan
+
+    assert np.all(np.isnan(compare_numba_vs_python(rc_cr2, w_in, tau)))
+
+    # Ensure that if the input waveform is less than 3 samples, an error is raised
+    with pytest.raises(DSPFatal):
+        rc_cr2(np.zeros(3), tau, np.zeros(3))
+
+    # ensure that a valid input gives the expected output
+    out_pulse = np.zeros_like(pulse_in)
+    rc_cr2(pulse_in, tau, out_pulse)
+
+    t = (
+        np.arange(8192 // 2, len(out_pulse) + 1) - 8192 // 2
+    )  # shift by 1 because of the 1 sample rise time
+    # This is the exact form of an RC-CR^2 filter applied to an exponential pulse...
+    w_out_expected = (
+        -zeta * t**2 * np.exp(-t / tau) / (2 * tau * (zeta - tau))
+        + t * (zeta**2 - 2 * zeta * tau) * np.exp(-t / tau) / (zeta - tau) ** 2
+        + zeta * tau**3 * np.exp(-t / zeta) / (zeta - tau) ** 3
+        - zeta * tau**3 * np.exp(-t / tau) / (zeta - tau) ** 3
+    )
+    w_out_expected *= amplitude
+    w_out_expected *= np.amax(out_pulse) / np.amax(
+        w_out_expected
+    )  # rescale because we abandoned gain scaling in the filter
+    w_out_expected = np.insert(
+        w_out_expected, 0, np.zeros(8192 // 2 - 1)
+    )  # subtract off the 1 we shifted
+
+    # Check that it works at float32 precision
+    pulse_in.astype(np.float32)
+    tau = np.array([tau], dtype=np.float32)[0]
+    assert np.allclose(
+        compare_numba_vs_python(rc_cr2, pulse_in, tau), w_out_expected, rtol=1e-01
+    )
+
+    pulse_in.astype(np.float64)
+    tau = np.array([tau], dtype=np.float64)[0]
+    assert np.allclose(
+        compare_numba_vs_python(rc_cr2, pulse_in, tau), w_out_expected, rtol=1e-01
+    )

--- a/tests/processors/test_time_point_thresh.py
+++ b/tests/processors/test_time_point_thresh.py
@@ -2,7 +2,12 @@ import numpy as np
 import pytest
 
 from dspeed.errors import DSPFatal
-from dspeed.processors import interpolated_time_point_thresh, time_point_thresh
+from dspeed.processors import (
+    bi_level_zero_crossing_time_points,
+    interpolated_time_point_thresh,
+    rc_cr2,
+    time_point_thresh,
+)
 
 
 def test_time_point_thresh(compare_numba_vs_python):
@@ -182,3 +187,152 @@ def test_interpolated_time_point_thresh(compare_numba_vs_python):
         compare_numba_vs_python(interpolated_time_point_thresh, w_in, 3.5, 0, 1, 108)
         == 4.5
     )
+
+
+def test_bi_level_zero_crossing_time_points(compare_numba_vs_python):
+    # Test exceptions and initial checks
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in = np.ones(100)
+    w_in[4] = np.nan
+    t_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(w_in, 100, 100, 100, 0, t_out)
+    assert np.isnan(t_out).all()
+
+    # ensure the DSPFatal is raised if initial timepoint is not an integer
+    t_start_in = 1.02
+    with pytest.raises(DSPFatal):
+        bi_level_zero_crossing_time_points(
+            np.ones(9), 100, 100, 100, t_start_in, np.ones(1)
+        )
+
+    # ensure the DSPFatal is raised if initial timepoint is not negative
+    t_start_in = -2
+    with pytest.raises(DSPFatal):
+        bi_level_zero_crossing_time_points(
+            np.ones(9), 100, 100, 100, t_start_in, np.ones(1)
+        )
+
+    # ensure the DSPFatal is raised if initial timepoint is outside length of waveform
+    t_start_in = 100
+    with pytest.raises(DSPFatal):
+        bi_level_zero_crossing_time_points(
+            np.ones(9), 100, 100, 100, t_start_in, np.ones(1)
+        )
+
+    early_trig = 500  # start pulse1 500 samples from the start of the wf
+    late_trig = 200  # start pulse2 200 samples after the midpoint of 8192 length wf
+    zeta = 30000  # the decay time constant of a pulse, in samples
+    amplitude = 1750
+    tau = 100  # the RC-CR^2 filter time constant
+
+    # Make the first pulse and RC-CR^2 filter it
+    ts = np.arange(0, 8192 // 2 - early_trig)
+    pulse = amplitude * np.exp(-1 * ts / zeta)
+    pulse = np.insert(pulse, 0, np.zeros(5))  # pad with 0s to avoid edge effects
+    out_pulse = np.zeros_like(pulse)
+
+    rc_cr2(pulse, tau, out_pulse)
+
+    pulse = np.insert(
+        out_pulse[5:], 0, np.zeros(early_trig)
+    )  # delay the start of the wf by early_trig
+
+    # Make the second pulse
+    ts = np.arange(0, 8192 // 2 - late_trig)
+    pulse2 = amplitude * np.exp(-1 * ts / zeta)
+    pulse2 = np.insert(pulse2, 0, np.zeros(5))  # avoid edge effects
+    out_pulse = np.zeros_like(pulse2)
+    rc_cr2(pulse2, tau, out_pulse)
+    pulse = np.insert(pulse, -1, np.zeros(late_trig))
+    pulse = np.insert(pulse, -1, out_pulse[5:])
+
+    gate_time = 1000
+    # Test that the filter reproduces 0 crossings at the expected points
+    # Test on positive polarity
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        pulse, 2000, -2000, gate_time, 0, t_trig_times_out
+    )
+
+    cross_1 = early_trig + 2 * tau - 1  # minus 1 from delay?
+    cross_2 = (
+        8192 // 2 + late_trig + 2 * tau - 2
+    )  # minus 1 from 1st pulse delay and again
+    assert np.allclose(int(t_trig_times_out[0]), cross_1, rtol=1)
+    assert np.allclose(int(t_trig_times_out[1]), cross_2, rtol=1)
+
+    # Check on negative polarity pulses
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        -1 * pulse, 2000, -2000, gate_time, 0, t_trig_times_out
+    )
+    assert np.allclose(int(t_trig_times_out[0]), cross_1, rtol=1)
+    assert np.allclose(int(t_trig_times_out[1]), cross_2, rtol=1)
+
+    # Check positive polarity pulses that cross 0 and never reach negative threshold return all nan
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        pulse, 2000, -300000, gate_time, 0, t_trig_times_out
+    )
+    assert np.isnan(t_trig_times_out).all()
+
+    # Check negative polarity pulses that cross 0 and never reach positive threshold return all nan
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        -1 * pulse, 300000, -2000, gate_time, 0, t_trig_times_out
+    )
+    assert np.isnan(t_trig_times_out).all()
+
+    # Check that pulses that never reach either threshold return all nan
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        pulse, 300000, 300000, gate_time, 0, t_trig_times_out
+    )
+    assert np.isnan(t_trig_times_out).all()
+
+    # Check that pulses that go up and never cross zero again return all nan
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        np.linspace(-1, 100, 101), 4, -4, gate_time, 0, t_trig_times_out
+    )
+    assert np.isnan(t_trig_times_out).all()
+
+    # Check that pulses that go down and never cross zero again return all nan
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        -1 * np.linspace(-1, 100, 101), 4, -4, gate_time, 0, t_trig_times_out
+    )
+    assert np.isnan(t_trig_times_out).all()
+
+    # Check positive polarity pulses where only 2nd peak crosses the threshold
+    scale_arr = np.full(8192 // 2, 1)
+    scale_arr = np.insert(scale_arr, -1, np.full(8192 // 2, 5))
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        pulse * scale_arr, 2000, -20000, gate_time, 0, t_trig_times_out
+    )
+    assert np.allclose(
+        int(t_trig_times_out[0]), cross_2, rtol=1
+    )  # only the 2nd time point should have been crossed
+
+    # Check positive polarity pulses where only 1st peak crosses the threshold
+    scale_arr = np.full(8192 // 2, 5)
+    scale_arr = np.insert(scale_arr, -1, np.full(8192 // 2, 1))
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        pulse * scale_arr, 2000, -20000, gate_time, 0, t_trig_times_out
+    )
+    assert np.allclose(
+        int(t_trig_times_out[0]), cross_1, rtol=1
+    )  # only the 2nd time point should have been crossed
+
+    # Check positive polarity pulses where only 2nd peak crosses both thresholds, but 1st peak passes negative but not within gate
+    scale_arr = np.full(8192 // 2, 1)
+    scale_arr = np.insert(scale_arr, -1, np.full(8192 // 2, 5))
+    t_trig_times_out = np.zeros(5)
+    bi_level_zero_crossing_time_points(
+        pulse * scale_arr, 50000, -2000, gate_time, 0, t_trig_times_out
+    )
+    assert np.allclose(
+        int(t_trig_times_out[0]), cross_2, rtol=1
+    )  # only the 2nd time point should have been crossed


### PR DESCRIPTION
I've added a recursive RC-CR^2 filter that is generically useful, but has specific use cases for identifying and tagging pile-up events. I've also added a function called `bi_level_zero_crossing_time_points` that returns the idx of a 0 crossing in-between crossings of both a positive and negative threshold within a gate time. This function is useful for identifying the number and polarity of pileup events within an RC-CR^2 filtered waveform. 