### PR TITLE
Removed deprecated np.float_ calls

### DIFF
--- a/src/dspeed/processors/get_multi_local_extrema.py
+++ b/src/dspeed/processors/get_multi_local_extrema.py
@@ -102,10 +102,10 @@ def get_multi_local_extrema(
     n_min_right_counter = 0
 
     # initialize temporary arrays
-    left_vt_max = np.zeros(len(vt_max_out), dtype=np.float_)
-    left_vt_min = np.zeros(len(vt_min_out), dtype=np.float_)
-    right_vt_max = np.zeros(len(vt_max_out), dtype=np.float_)
-    right_vt_min = np.zeros(len(vt_min_out), dtype=np.float_)
+    left_vt_max = np.zeros(len(vt_max_out), dtype=np.float64)
+    left_vt_min = np.zeros(len(vt_min_out), dtype=np.float64)
+    right_vt_max = np.zeros(len(vt_max_out), dtype=np.float64)
+    right_vt_min = np.zeros(len(vt_min_out), dtype=np.float64)
 
     left_vt_max[:] = np.nan
     left_vt_min[:] = np.nan


### PR DESCRIPTION
`get_multi_local_extrema` was calling `np.float_` which is deprecated in numpy 2.0 and is causing BuildTheDocs to fail in other repos. I've replaced these calls with `np.float64` 