### PR TITLE
Bug fixes

### DIFF
--- a/src/dspeed/build_dsp.py
+++ b/src/dspeed/build_dsp.py
@@ -17,7 +17,7 @@ from yaml import safe_load
 from .errors import DSPFatal
 from .processing_chain import build_processing_chain
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("dspeed")
 
 
 def build_dsp(

--- a/src/dspeed/logging.py
+++ b/src/dspeed/logging.py
@@ -15,7 +15,7 @@ CRITICAL = logging.CRITICAL
 def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
     """Setup a colorful logging output.
 
-    If `logger` is None, sets up only the ``pygama`` logger.
+    If `logger` is None, sets up only the ``dpeed`` logger.
 
     Parameters
     ----------
@@ -26,16 +26,21 @@ def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
 
     Examples
     --------
-    >>> from pygama import logging
+    >>> from dspeed import logging
     >>> logging.setup(level=logging.DEBUG)
     """
     handler = colorlog.StreamHandler()
+    colors = colorlog.default_log_colors.copy()
+    colors["DEBUG"] = "bold_cyan"
     handler.setFormatter(
-        colorlog.ColoredFormatter("%(log_color)s%(name)s [%(levelname)s] %(message)s")
+        colorlog.ColoredFormatter(
+            "%(log_color)s%(name)s [%(levelname)s] %(message)s",
+            log_colors=colors
+        )
     )
 
     if logger is None:
-        logger = colorlog.getLogger("pygama")
+        logger = colorlog.getLogger("dspeed")
 
     logger.setLevel(level)
     logger.addHandler(handler)

--- a/src/dspeed/logging.py
+++ b/src/dspeed/logging.py
@@ -34,8 +34,7 @@ def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
     colors["DEBUG"] = "bold_cyan"
     handler.setFormatter(
         colorlog.ColoredFormatter(
-            "%(log_color)s%(name)s [%(levelname)s] %(message)s",
-            log_colors=colors
+            "%(log_color)s%(name)s [%(levelname)s] %(message)s", log_colors=colors
         )
     )
 

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -28,7 +28,7 @@ from .units import unit_registry as ureg
 from .utils import ProcChainVarBase
 from .utils import numba_defaults_kwargs as nb_kwargs
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("dspeed")
 sto = lh5.LH5Store()
 
 # Filler value for variables to be automatically deduced later

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -825,7 +825,10 @@ class ProcessingChain:
                     if unit == ureg.dimensionless:
                         unit = None
                 elif lhs.unit is not None and rhs.unit is not None:
-                    unit = op_form.format(str(lhs.unit), str(rhs.unit))
+                    if type(node.op) in (ast.Mult, ast.Div, ast.FloorDiv):
+                        unit = op_form.format(str(lhs.unit), str(rhs.unit))
+                    else:
+                        unit = str(lhs.unit)
                 elif lhs.unit is not None:
                     unit = lhs.unit
                 else:

--- a/src/dspeed/processors/svm.py
+++ b/src/dspeed/processors/svm.py
@@ -4,9 +4,7 @@ import pickle
 from typing import Callable
 
 import numpy as np
-from numba import guvectorize
 
-from ..utils import numba_defaults_kwargs as nb_kwargs
 from ..utils import GUFuncWrapper
 
 
@@ -55,11 +53,11 @@ def svm_predict(svm_file: str) -> Callable:
         if w_in.ndim == 1:
             return svm.predict(w_in.reshape(1, -1))
         else:
-            return svm.predict(w_in)        
+            return svm.predict(w_in)
 
     return GUFuncWrapper(
         svm_proc,
         name=svm_file if isinstance(svm_file, str) else "svm_null",
-        signature='(n)->()',
-        types="f->f"
+        signature="(n)->()",
+        types="f->f",
     )

--- a/src/dspeed/utils.py
+++ b/src/dspeed/utils.py
@@ -15,8 +15,11 @@ class GUFuncWrapper:
     using the "factory" method and typically utilize "init_args"
 
     Example 1:
-    --------
-        ...set up some object `obj` that has a function we want to call on w_in
+    ----------
+    .. highlight::python
+    .. code-block:: python
+
+        set up some object `obj` that has a function we want to call on w_in
         gufunc = gufunc_wrapper(
             lambda w_in: obj.execute(w_in, args...),
             "(n)->()",
@@ -25,6 +28,9 @@ class GUFuncWrapper:
 
     Example 2:
     ----------
+    .. highlight::python
+    .. code-block:: python
+
         fun is a vectorized python function, but we want to use ufunc interface
         gufunc = gufunc_wrapper(
             lambda w_in, a, w_out: fun(w_in, a, out=w_out, ...more kwargs),
@@ -33,6 +39,7 @@ class GUFuncWrapper:
             vectorized=True,
             copy_out=False
         )
+
     """
 
     def __init__(

--- a/src/dspeed/utils.py
+++ b/src/dspeed/utils.py
@@ -19,7 +19,7 @@ class GUFuncWrapper:
     .. highlight::python
     .. code-block:: python
 
-        set up some object `obj` that has a function we want to call on w_in
+        set up some object 'obj' that has a function we want to call on w_in
         gufunc = gufunc_wrapper(
             lambda w_in: obj.execute(w_in, args...),
             "(n)->()",


### PR DESCRIPTION
- Added GUFuncWrapper class to enable wrapping of factory-generated processors without using numba in forceobj mode. Numba functions never leave memory, so this was causing memory usage to increase over time
- Applied GUFuncWrapper to svm
- Fixed bug in automatic unit handling with + and - operators
- Fixed logging module requiring the use of the pygama logger and not being able to activate separately from others
- Changed debug color palette in logger to be more legible (especially in jupyter) 