### PR TITLE
Make sure t0 filter is zero-area

### DIFF
--- a/src/dspeed/processors/kernels.py
+++ b/src/dspeed/processors/kernels.py
@@ -51,7 +51,7 @@ def t0_filter(rise: int, fall: int, kernel: np.array) -> None:
         raise DSPFatal("The length of the output kernel must equal rise+fall")
 
     for i in range(int(rise)):
-        kernel[i] = 2 * (int(rise) - i) / (rise*(rise+1))
+        kernel[i] = 2 * (int(rise) - i) / (rise * (rise + 1))
     for i in range(int(rise), len(kernel), 1):
         kernel[i] = -1 / fall
 

--- a/src/dspeed/processors/kernels.py
+++ b/src/dspeed/processors/kernels.py
@@ -47,8 +47,11 @@ def t0_filter(rise: int, fall: int, kernel: np.array) -> None:
     if fall < 0:
         raise DSPFatal("The length of the fall section must be positive")
 
+    if len(kernel) != rise + fall:
+        raise DSPFatal("The length of the output kernel must equal rise+fall")
+
     for i in range(int(rise)):
-        kernel[i] = 2 * (int(rise) - i) / (rise**2)
+        kernel[i] = 2 * (int(rise) - i) / (rise*(rise+1))
     for i in range(int(rise), len(kernel), 1):
         kernel[i] = -1 / fall
 


### PR DESCRIPTION
Fixed normalization of triangle and throw error if length of kernel is incorrect