### PR TITLE
wf browser fix for vov

### DIFF
--- a/src/dspeed/vis/waveform_browser.py
+++ b/src/dspeed/vis/waveform_browser.py
@@ -436,7 +436,9 @@ class WaveformBrowser:
                 if isinstance(
                     data, (lgdo.ArrayOfEqualSizedArrays, lgdo.VectorOfVectors)
                 ):
-                    vals = list(data.nda[i_tb])
+
+                    vals = list(data.view_as("ak")[i_tb].to_numpy())
+
                 else:
                     vals = [data.nda[i_tb]]
 


### PR DESCRIPTION
I found an issue when using the waveform browser for plotting sipm t0s, when the field is a VoV it crashes since there is no `.nda` for VoV. This alternative should fix that...