### PR TITLE
feat(build-dsp): add per-processor profiling report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies=[
     "numpy>2",
     "parse",
     "pint",
+    "psutil",
     "pyarrow",
     "pyyaml",
     "scipy",

--- a/src/dspeed/build_dsp.py
+++ b/src/dspeed/build_dsp.py
@@ -23,6 +23,62 @@ from .processing_chain import build_processing_chain
 
 log = logging.getLogger("dspeed")
 
+_PROFILE_TOP_N = 15
+_PROFILE_NAME_W = 52
+
+
+def _log_profile_report(proc_chain, n_entries: int) -> None:
+    profile = proc_chain.get_profile()
+    if not profile:
+        return
+
+    def _rmax(s):
+        v = s["rss_delta_max_mb"]
+        return max(v, 0.0) if v != float("-inf") else 0.0
+
+    total_wall = sum(s["wall_s"] for s in profile.values())
+    total_rss_max = sum(_rmax(s) for s in profile.values())
+    total_rss_avg = sum(s["rss_delta_avg_mb"] for s in profile.values())
+
+    sorted_procs = sorted(profile.items(), key=lambda x: x[1]["wall_s"], reverse=True)
+    n_total = len(sorted_procs)
+    shown, rest = sorted_procs[:_PROFILE_TOP_N], sorted_procs[_PROFILE_TOP_N:]
+
+    w = _PROFILE_NAME_W
+    sep = "─" * (w + 46)
+
+    log.info(
+        f"=== DSP profiling report ({n_total} processors, {n_entries} entries) ==="
+    )
+    log.info(
+        f" {'processor':<{w}}  {'wall_s':>8}  {'%':>6}  {'Δrss_max':>10}  {'Δrss_avg':>10}"
+    )
+    log.info(sep)
+
+    for name, s in shown:
+        wall = s["wall_s"]
+        pct = 100 * wall / total_wall if total_wall else 0.0
+        rmax = _rmax(s)
+        ravg = s["rss_delta_avg_mb"]
+        label = (name[: w - 1] + "…") if len(name) > w else name
+        log.info(
+            f" {label:<{w}}  {wall:>8.3f}  {pct:>5.1f}%  {rmax:>+9.2f} MB  {ravg:>+9.2f} MB"
+        )
+
+    if rest:
+        rest_wall = sum(s["wall_s"] for _, s in rest)
+        rest_pct = 100 * rest_wall / total_wall if total_wall else 0.0
+        label = f"[{len(rest)} more processors]"
+        log.info(
+            f" {label:<{w}}  {rest_wall:>8.3f}  {rest_pct:>5.1f}%  {'...':>12}  {'...':>12}"
+        )
+
+    log.info(sep)
+    log.info(
+        f" {'total':<{w}}  {total_wall:>8.3f}  {'100.0%':>6}"
+        f"  {total_rss_max:>+9.2f} MB  {total_rss_avg:>+9.2f} MB"
+    )
+
 
 def build_dsp(
     raw_in: str | LGDO,
@@ -438,14 +494,7 @@ def build_dsp(
         log.debug(f"Table {tb} loading time: {loading_time:.2f} seconds")
         log.debug(f"Table {tb} write time: {write_time:.2f} seconds")
         log.debug(f"Table {tb} processing time: {processing_time:.2f} seconds")
-
-        if log.getEffectiveLevel() >= logging.DEBUG:
-            times = proc_chain.get_timing()
-            log.debug("Processor timing info: ")
-            for proc, t in dict(
-                sorted(times.items(), key=lambda item: item[1], reverse=True)
-            ).items():
-                log.debug(f"{proc}: {t:.3f} s")
+        _log_profile_report(proc_chain, tot_n_rows)
 
     if isinstance(dsp_st, Struct):
         return dsp_st

--- a/src/dspeed/build_dsp.py
+++ b/src/dspeed/build_dsp.py
@@ -32,51 +32,38 @@ def _log_profile_report(proc_chain, n_entries: int) -> None:
     if not profile:
         return
 
-    def _rmax(s):
-        v = s["rss_delta_max_mb"]
-        return max(v, 0.0) if v != float("-inf") else 0.0
-
     total_wall = sum(s["wall_s"] for s in profile.values())
-    total_rss_max = sum(_rmax(s) for s in profile.values())
-    total_rss_avg = sum(s["rss_delta_avg_mb"] for s in profile.values())
+    total_rss = sum(s["rss_setup_mb"] for s in profile.values())
 
     sorted_procs = sorted(profile.items(), key=lambda x: x[1]["wall_s"], reverse=True)
     n_total = len(sorted_procs)
     shown, rest = sorted_procs[:_PROFILE_TOP_N], sorted_procs[_PROFILE_TOP_N:]
 
     w = _PROFILE_NAME_W
-    sep = "─" * (w + 46)
+    sep = "─" * (w + 36)
 
     log.info(
         f"=== DSP profiling report ({n_total} processors, {n_entries} entries) ==="
     )
-    log.info(
-        f" {'processor':<{w}}  {'wall_s':>8}  {'%':>6}  {'Δrss_max':>10}  {'Δrss_avg':>10}"
-    )
+    log.info(f" {'processor':<{w}}  {'wall_s':>8}  {'%':>6}  {'setup_MB':>10}")
     log.info(sep)
 
     for name, s in shown:
         wall = s["wall_s"]
         pct = 100 * wall / total_wall if total_wall else 0.0
-        rmax = _rmax(s)
-        ravg = s["rss_delta_avg_mb"]
+        rss = s["rss_setup_mb"]
         label = (name[: w - 1] + "…") if len(name) > w else name
-        log.info(
-            f" {label:<{w}}  {wall:>8.3f}  {pct:>5.1f}%  {rmax:>+9.2f} MB  {ravg:>+9.2f} MB"
-        )
+        log.info(f" {label:<{w}}  {wall:>8.3f}  {pct:>5.1f}%  {rss:>+9.2f} MB")
 
     if rest:
         rest_wall = sum(s["wall_s"] for _, s in rest)
         rest_pct = 100 * rest_wall / total_wall if total_wall else 0.0
         label = f"[{len(rest)} more processors]"
-        log.info(
-            f" {label:<{w}}  {rest_wall:>8.3f}  {rest_pct:>5.1f}%  {'...':>12}  {'...':>12}"
-        )
+        log.info(f" {label:<{w}}  {rest_wall:>8.3f}  {rest_pct:>5.1f}%  {'...':>12}")
 
     log.info(sep)
     log.info(
-        f" {'total':<{w}}  {total_wall:>8.3f}  {'100.0%':>6}"
-        f"  {total_rss_max:>+9.2f} MB  {total_rss_avg:>+9.2f} MB"
+        f" {'total':<{w}}  {total_wall:>8.3f}  {'100.0%':>6}  {total_rss:>+9.2f} MB"
     )
 
 

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import lgdo
 import numpy as np
+import psutil
 from numba import guvectorize
 from pint import Quantity, Unit
 from yaml import safe_load
@@ -34,6 +35,8 @@ from .utils import ProcChainVarBase
 from .utils import numba_defaults_kwargs as nb_kwargs
 
 log = logging.getLogger("dspeed")
+
+_psutil_proc = psutil.Process()
 
 # Filler value for variables to be automatically deduced later
 auto = "auto"
@@ -1133,9 +1136,24 @@ class ProcessingChain:
         else:
             return var.vector_len
 
+    def get_profile(self) -> dict[str, dict]:
+        """Get profiling stats for each processor in the processing chain.
+
+        Returns a dict keyed by processor string representation with entries:
+        ``wall_s``, ``rss_delta_max_mb``, ``rss_delta_avg_mb``.
+        """
+        return {
+            str(proc): {
+                "wall_s": proc.time_total,
+                "rss_delta_max_mb": proc.rss_delta_max_mb,
+                "rss_delta_avg_mb": proc.rss_delta_avg_mb,
+            }
+            for proc in self._proc_managers
+        }
+
     def get_timing(self) -> dict[str, float]:
-        """Get the timing of each processor in the processing chain."""
-        return {str(proc): proc.time_total for proc in self._proc_managers}
+        """Get the wall time of each processor in the processing chain."""
+        return {name: s["wall_s"] for name, s in self.get_profile().items()}
 
     # round value
     def _round(
@@ -1465,8 +1483,10 @@ class ProcessorManager:
         self.args = []
         # dict of kws -> raw values and buffers from params; we will fill this soon
         self.kwargs = {}
-        # store time taken by processor
         self.time_total = 0
+        self.rss_delta_max_mb = float("-inf")
+        self.rss_delta_avg_mb = 0.0
+        self._n_calls = 0
 
         # Get the signature and list of valid types for the function
         self.signature = func.signature if signature is None else signature
@@ -1719,14 +1739,19 @@ class ProcessorManager:
                 self.kwargs[arg_name] = param
 
     def execute(self) -> None:
-        start = time.time()
+        rss0 = _psutil_proc.memory_info().rss
+        start = time.perf_counter()
         try:
             self.processor(*self.args, **self.kwargs)
         except Exception as e:
             log.error(f"Error processing {str(self)}: {e}")
             traceback.print_exc()
             raise e
-        self.time_total += time.time() - start
+        self.time_total += time.perf_counter() - start
+        delta_mb = (_psutil_proc.memory_info().rss - rss0) / 1024**2
+        self.rss_delta_max_mb = max(self.rss_delta_max_mb, delta_mb)
+        self._n_calls += 1
+        self.rss_delta_avg_mb += (delta_mb - self.rss_delta_avg_mb) / self._n_calls
 
     def __str__(self) -> str:
         return (
@@ -1827,6 +1852,9 @@ class UnitConversionManager(ProcessorManager):
         ]
         self.kwargs = {}
         self.time_total = 0
+        self.rss_delta_max_mb = float("-inf")
+        self.rss_delta_avg_mb = 0.0
+        self._n_calls = 0
 
 
 class IOManager(metaclass=ABCMeta):

--- a/src/dspeed/processing_chain.py
+++ b/src/dspeed/processing_chain.py
@@ -1145,8 +1145,7 @@ class ProcessingChain:
         return {
             str(proc): {
                 "wall_s": proc.time_total,
-                "rss_delta_max_mb": proc.rss_delta_max_mb,
-                "rss_delta_avg_mb": proc.rss_delta_avg_mb,
+                "rss_setup_mb": proc.rss_setup_mb,
             }
             for proc in self._proc_managers
         }
@@ -1484,9 +1483,7 @@ class ProcessorManager:
         # dict of kws -> raw values and buffers from params; we will fill this soon
         self.kwargs = {}
         self.time_total = 0
-        self.rss_delta_max_mb = float("-inf")
-        self.rss_delta_avg_mb = 0.0
-        self._n_calls = 0
+        self.rss_setup_mb = 0.0
 
         # Get the signature and list of valid types for the function
         self.signature = func.signature if signature is None else signature
@@ -1739,7 +1736,6 @@ class ProcessorManager:
                 self.kwargs[arg_name] = param
 
     def execute(self) -> None:
-        rss0 = _psutil_proc.memory_info().rss
         start = time.perf_counter()
         try:
             self.processor(*self.args, **self.kwargs)
@@ -1748,10 +1744,6 @@ class ProcessorManager:
             traceback.print_exc()
             raise e
         self.time_total += time.perf_counter() - start
-        delta_mb = (_psutil_proc.memory_info().rss - rss0) / 1024**2
-        self.rss_delta_max_mb = max(self.rss_delta_max_mb, delta_mb)
-        self._n_calls += 1
-        self.rss_delta_avg_mb += (delta_mb - self.rss_delta_avg_mb) / self._n_calls
 
     def __str__(self) -> str:
         return (
@@ -1852,9 +1844,7 @@ class UnitConversionManager(ProcessorManager):
         ]
         self.kwargs = {}
         self.time_total = 0
-        self.rss_delta_max_mb = float("-inf")
-        self.rss_delta_avg_mb = 0.0
-        self._n_calls = 0
+        self.rss_setup_mb = 0.0
 
 
 class IOManager(metaclass=ABCMeta):
@@ -2656,6 +2646,8 @@ def build_processing_chain(
                 }
             )
 
+            _rss0 = _psutil_proc.memory_info().rss
+
             # if init_args are defined, parse any strings and then call func
             # as a factory/constructor function
             try:
@@ -2757,6 +2749,9 @@ def build_processing_chain(
 
             else:
                 proc_chain.add_processor(func, *params, kw_params, **kwargs)
+                proc_chain._proc_managers[-1].rss_setup_mb = (
+                    _psutil_proc.memory_info().rss - _rss0
+                ) / 1024**2
 
         except Exception as e:
             raise ProcessingChainError(


### PR DESCRIPTION
## Summary

- `ProcessorManager.execute()` now measures wall time (`perf_counter`) and RSS delta (`psutil`) around each processor call per block, accumulating total wall time, per-block max RSS delta, and per-block average RSS delta
- `ProcessingChain` gains `get_profile()` returning the full stats dict; `get_timing()` delegates to it (backward compatible)
- `build_dsp` logs an INFO-level profiling table after each table is processed, showing the top 15 processors by wall time with wall time (s + %), max RSS delta, and average RSS delta; remaining processors are collapsed into a single summary line
- `psutil` added as a package dependency

Example output:
```
=== DSP profiling report (34 processors, 10000 entries) ===
 processor                                            wall_s       %    Δrss_max    Δrss_avg
────────────────────────────────────────────────────────────────────────────────────────────────────
 fft_convolve_wf(wf_blsub[:round(…)], cusp_k…)        1.234   25.0%   +12.30 MB    +0.41 MB
 fft_convolve_wf(wf_blsub[:round(…)], zac_ke…)        1.107   22.4%   +12.10 MB    +0.39 MB
 cusp_filter(db.cusp.sigma/wf_blsub.period, …)        0.781   15.8%    +8.40 MB    +0.28 MB
 ...
 [19 more processors]                                  0.512   10.4%         ...         ...
────────────────────────────────────────────────────────────────────────────────────────────────────
 total                                                  4.941  100.0%   +41.00 MB    +1.34 MB
```

## Test plan

- [x] All existing tests pass (`tests/test_processing_chain.py`, `tests/test_build_dsp.py`)
- [ ] Visually verify report appears in INFO log output when running `build_dsp` on a real file